### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "bundler"
+    vendor: true
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "chore"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Because: We want package updates to be handled automatically

This commit:
- Sets up a dependabot yml file to manage rubygem and npm package updates
- Allows github actions to be updated through this also

They have been scheduled to weekly