### PR TITLE
Add heading styles to tailwind base layer

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,29 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  h1 {
+    @apply text-5xl font-medium leading-tight mt-0 mb-2 text-gray-600;
+  }
+
+  h2 {
+    @apply text-4xl font-medium leading-tight mt-0 mb-2 text-gray-600;
+  }
+
+  h3 {
+    @apply text-3xl font-medium leading-tight mt-0 mb-2 text-gray-600;
+  }
+
+  h4 {
+    @apply text-2xl font-medium leading-tight mt-0 mb-2 text-gray-600;
+  }
+
+  h5 {
+    @apply text-xl font-medium leading-tight mt-0 mb-2 text-gray-600;
+  }
+
+  h6 {
+    @apply text-base font-medium leading-tight mt-0 mb-2 text-gray-600;
+  }
+}


### PR DESCRIPTION
Because: We want consistant heading element styles across the application

This commit
  - Adds the heading styles to the tailwind base layer