### PR TITLE
Add inline svgs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'cssbundling-rails'
 gem 'devise', '~> 4.8'
 gem 'devise_invitable', '~> 2.0.0'
+gem 'inline_svg'
 gem 'jsbundling-rails'
 gem 'stimulus-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       concurrent-ruby (~> 1.0)
     imagen (0.1.8)
       parser (>= 2.5, != 2.5.1.1)
+    inline_svg (1.8.0)
+      activesupport (>= 3.0)
+      nokogiri (>= 1.6)
     io-wait (0.2.1)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -310,6 +313,7 @@ DEPENDENCIES
   cuprite
   devise (~> 4.8)
   devise_invitable (~> 2.0.0)
+  inline_svg
   jbuilder (~> 2.11)
   jsbundling-rails
   listen (~> 3.7)

--- a/app/assets/images/icons/close-button.svg
+++ b/app/assets/images/icons/close-button.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>

--- a/app/assets/images/icons/home.svg
+++ b/app/assets/images/icons/home.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>

--- a/app/assets/images/icons/menu.svg
+++ b/app/assets/images/icons/menu.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"></path></svg>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -28,22 +28,7 @@
           data-action="class-toggle#switch"
         >
           <span class="sr-only">Close sidebar</span>
-          <!-- Heroicon name: outline/x -->
-          <svg
-            class="h-6 w-6 text-white"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          <%= inline_svg 'icons/close-button', class: 'h-6 w-6 text-white' %>
         </button>
       </div>
 
@@ -56,21 +41,7 @@
       >
         <div class="space-y-1 px-2">
           <%= link_to root_path, class: "group flex items-center rounded-md bg-violet-200 px-2 py-2 text-base font-medium text-white", aria: { current: 'page' } do %>
-            <svg
-              class="mr-4 h-6 w-6 flex-shrink-0 text-orange-500"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-              />
-            </svg>
+            <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
           <% end %>
         </div>
@@ -95,21 +66,7 @@
       >
         <div class="space-y-1 px-2">
           <%= link_to root_path, class: "group flex items-center rounded-md bg-violet-200 px-2 py-2 text-sm font-medium leading-6 text-white", aria: { current: 'page' } do %>
-            <svg
-              class="mr-4 h-6 w-6 flex-shrink-0 text-orange-500"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-              />
-            </svg>
+            <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
           <% end %>
         </div>
@@ -126,22 +83,7 @@
         class="border-r border-gray-200 px-4 text-gray-400 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-cyan-500 lg:hidden"
       >
         <span class="sr-only">Open sidebar</span>
-        <!-- Heroicon name: outline/menu-alt-1 -->
-        <svg
-          class="h-6 w-6"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 6h16M4 12h8m-8 6h16"
-          />
-        </svg>
+        <%= inline_svg 'icons/menu', class: 'h-6 w-6' %>
       </button>
     </div>
     <main class="flex-1 pb-8"></main>


### PR DESCRIPTION
Because:
Svgs should be stored in the icons image folder and not rendered straight into the html markup

This commit:
  - Adds the inline svg gem
  - Adds the close button svg
  - Adds the menu icon svg
  - Adds the home icon svg
  - Removes the directly rendered svgs and replaces them with inline svgs rendered from the icons directory