### PR TITLE
Add hover effect to menu links

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -40,7 +40,7 @@
         aria-label="Sidebar"
       >
         <div class="space-y-1 px-2">
-          <%= link_to root_path, class: "group flex items-center rounded-md bg-violet-200 px-2 py-2 text-base font-medium text-white", aria: { current: 'page' } do %>
+          <%= link_to root_path, class: "group flex items-center rounded-md bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium text-white", aria: { current: 'page' } do %>
             <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
           <% end %>
@@ -65,7 +65,7 @@
         aria-label="Sidebar"
       >
         <div class="space-y-1 px-2">
-          <%= link_to root_path, class: "group flex items-center rounded-md bg-violet-200 px-2 py-2 text-sm font-medium leading-6 text-white", aria: { current: 'page' } do %>
+          <%= link_to root_path, class: "group flex items-center rounded-md bg-violet-200 hover:bg-violet-300 px-2 py-2 text-sm font-medium leading-6 text-white", aria: { current: 'page' } do %>
             <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
           <% end %>


### PR DESCRIPTION
Because:
There is no visual feedback when a menu item is hovered over except for the mouse cursor changing

This commit:
  - Changes the background colour of the menu item on hover