### PR TITLE
Flash helper styling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Layout/LineLength:
 Style/StringLiterals:
   Exclude:
     - "db/migrate/*.rb"
+Lint/MissingSuper:
+  Exclude:
+    - "app/components/**/*.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'inline_svg'
 gem 'jsbundling-rails'
 gem 'sprockets-rails'
 gem 'stimulus-rails'
+gem 'view_component', '~> 2.48'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,9 @@ GEM
       rainbow (>= 2.1, < 4.0)
       rugged (>= 0.27, < 1.3)
     unicode-display_width (2.1.0)
+    view_component (2.48.0)
+      activesupport (>= 5.0.0, < 8.0)
+      method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -330,6 +333,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   undercover
+  view_component (~> 2.48)
   web-console (>= 4.1.0)
 
 RUBY VERSION

--- a/app/assets/images/icons/check_circle_outline.svg
+++ b/app/assets/images/icons/check_circle_outline.svg
@@ -1,0 +1,3 @@
+<svg data-test-id="check-circle-outline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/app/assets/images/icons/close_button_solid.svg
+++ b/app/assets/images/icons/close_button_solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+</svg>

--- a/app/assets/images/icons/logout.svg
+++ b/app/assets/images/icons/logout.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+</svg>

--- a/app/assets/images/icons/x_circle_outline.svg
+++ b/app/assets/images/icons/x_circle_outline.svg
@@ -1,0 +1,3 @@
+<svg data-test-id="x-circle-outline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/app/components/temporary_notification_component.html.erb
+++ b/app/components/temporary_notification_component.html.erb
@@ -1,0 +1,28 @@
+<div
+class="max-w-sm w-full bg-white shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden"
+data-transition-target="item"
+data-transition-enter="transform ease-out duration-300 transition"
+data-transition-enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+data-transition-enter-end="translate-y-0 opacity-100 sm:translate-x-0"
+data-transition-leave="transition ease-in duration-100"
+data-transition-leave-start="opacity-100"
+data-transition-leave-end="opacity-0"
+data-test-id='flash'
+>
+  <div class="p-4">
+    <div class="flex items-start">
+      <div class="flex-shrink-0">
+        <%= inline_svg type_icon, class: type_class %>
+      </div>
+      <div class="ml-3 w-0 flex-1 pt-0.5">
+        <p class="text-sm font-medium text-gray-900"><%= @message.html_safe %></p>
+      </div>
+      <div class="ml-4 flex-shrink-0 flex">
+        <button class="bg-white rounded-md inline-flex text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" data-action="transition#close">
+          <span class="sr-only">Close</span>
+          <%= inline_svg 'icons/close_button_solid', class: 'h-5 w-5' %>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/temporary_notification_component.rb
+++ b/app/components/temporary_notification_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class TemporaryNotificationComponent < ViewComponent::Base
+  def initialize(type:, message:)
+    @type = type
+    @message = message
+  end
+
+  def type_icon
+    {
+      alert: 'icons/x_circle_outline',
+      notice: 'icons/check_circle_outline'
+    }.fetch(@type.to_sym)
+  end
+
+  def type_class
+    {
+      alert: 'h-6 w-6 text-red-400',
+      notice: 'h-6 w-6 text-green-400'
+    }.fetch(@type.to_sym)
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,7 +2,10 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application";
+import { application } from "./application"
 
-import ClassToggleController from "./class_toggle_controller.js";
-application.register("class-toggle", ClassToggleController);
+import ClassToggleController from "./class_toggle_controller.js"
+application.register("class-toggle", ClassToggleController)
+
+import TransitionController from "./transition_controller.js"
+application.register("transition", TransitionController)

--- a/app/javascript/controllers/transition_controller.js
+++ b/app/javascript/controllers/transition_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+import { enter, leave } from "el-transition"
+
+// Connects to data-controller="transition"
+export default class extends Controller {
+  static targets = ["item"]
+
+  itemTargetConnected(element) {
+    enter(element)
+  }
+
+  close() {
+    this.itemTargets.forEach(element => leave(element))
+  }
+}

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -47,6 +47,14 @@
             Home
           <% end %>
         </div>
+        <div class="space-y-1 px-2">
+          <%= link_to destroy_user_session_path, method: :delete, class: "group flex items-center rounded-md
+          bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium
+          text-white", aria: { current: 'page' } do %> 
+            <%= inline_svg 'icons/logout', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
+            Sign Out
+          <% end %>
+        </div>
       </nav>
     </div>
 
@@ -72,6 +80,14 @@
           text-white", aria: { current: 'page' } do %> 
             <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
+          <% end %>
+        </div>
+        <div class="space-y-1 px-2">
+          <%= link_to destroy_user_session_path, method: :delete, class: "group flex items-center rounded-md
+          bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium
+          text-white", aria: { current: 'page' } do %> 
+            <%= inline_svg 'icons/logout', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
+            Sign Out
           <% end %>
         </div>
       </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,12 +9,13 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
   <body class="h-full">
-    <% flash.each do |type, message| %>
-      <div data-test-id='flash'>
-        <button class='close' data-dismiss='alert'>&times;</button>
-        <%= message.html_safe %>
-      </div>
-    <% end %>
     <%= yield %>
+    <div aria-live="assertive" class="z-50 fixed inset-0 flex items-end px-4 py-6 pointer-events-none sm:p-6 sm:items-start" data-controller="transition">
+      <div class="w-full flex flex-col items-center space-y-4 sm:items-end">
+        <% flash.each do |type, message| %>
+          <%= render TemporaryNotificationComponent.new(type: type, message: message) %>
+        <% end %>
+      </div>
+    </div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^7.0.1",
     "@tailwindcss/forms": "^0.4.0",
     "autoprefixer": "^10.4.2",
+    "el-transition": "^0.0.7",
     "esbuild": "^0.14.16",
     "postcss": "^8.4.6",
     "tailwindcss": "^3.0.18",

--- a/spec/components/temporary_notification_component_spec.rb
+++ b/spec/components/temporary_notification_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe TemporaryNotificationComponent, type: :component do
+  subject(:temporary_notification) { described_class.new(type: type, message: message) }
+
+  context 'with a type of alert' do
+    let(:type) { 'alert' }
+    let(:message) { '' }
+
+    it 'renders the x_circle_outline alert svg' do
+      render_inline(temporary_notification)
+
+      expect(rendered_component).to have_selector("svg[data-test-id='x-circle-outline']")
+    end
+
+    it 'renders the alert css' do
+      render_inline(temporary_notification)
+
+      expect(rendered_component).to have_css '.text-red-400'
+    end
+  end
+
+  context 'with a type of notice' do
+    let(:type) { 'notice' }
+    let(:message) { '' }
+
+    it 'renders the check_circle_outline svg' do
+      render_inline(temporary_notification)
+
+      expect(rendered_component).to have_selector("svg[data-test-id='check-circle-outline']")
+    end
+
+    it 'renders the alert css' do
+      render_inline(temporary_notification)
+
+      expect(rendered_component).to have_css '.text-green-400'
+    end
+  end
+end

--- a/spec/support/view_component.rb
+++ b/spec/support/view_component.rb
@@ -1,0 +1,7 @@
+require 'view_component/test_helpers'
+require 'capybara/rspec'
+
+RSpec.configure do |config|
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
+end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,8 @@ module.exports = {
     "./app/helpers/**/*.rb",
     "./app/javascript/**/*.js",
     "./app/form_builders/**/*.rb",
+    "./app/components/**/*.rb",
+    "./app/components/**/*.html.erb"
   ],
   plugins: [require("@tailwindcss/forms")],
   theme: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,6 +277,11 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+el-transition@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/el-transition/-/el-transition-0.0.7.tgz#714fd47aa46fc2ff3df7d59e789271aa09f247d0"
+  integrity sha512-a23pEa7ahqLmBIEqtxi8CdL6CRLF52ZoAwawDFTD1IDkegrL4iValQAj6IMEgIEXPSrXZtx/Nr/ej6ebov4uoA==
+
 electron-to-chromium@^1.4.17:
   version "1.4.60"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.60.tgz#2b824d862f068a9794b2b75d66ad40ff44745f18"


### PR DESCRIPTION
Because:
Flash messages need to be displayed to the user

This commit:
  - Adds the view component gem
  - Adds the el-transition npm package
  - Adds various svg icons for logout, close button, check circle and x circle outline
  - Creates a transition stimulus controller
  - Creates a TemporaryNotification component to display flash messages
  - Render the component from the applicaiton layout file

The Component is reusable as any kind of temporary notification where you either don't want it to display beyond the current page or just when closed via the close button on the notification.