### PR TITLE
fix: move all menu items within div to align them correctly

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -41,15 +41,13 @@
       >
         <div class="space-y-1 px-2">
           <%= link_to root_path, class: "group flex items-center rounded-md
-          bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium
+          hover:bg-violet-200 px-2 py-2 text-base font-medium
           text-white", aria: { current: 'page' } do %> 
             <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
           <% end %>
-        </div>
-        <div class="space-y-1 px-2">
           <%= link_to destroy_user_session_path, method: :delete, class: "group flex items-center rounded-md
-          bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium
+          hover:bg-violet-200 px-2 py-2 text-base font-medium
           text-white", aria: { current: 'page' } do %> 
             <%= inline_svg 'icons/logout', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Sign Out
@@ -76,15 +74,13 @@
       >
         <div class="space-y-1 px-2">
           <%= link_to root_path, class: "group flex items-center rounded-md
-          bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium
+          hover:bg-violet-200 px-2 py-2 text-base font-medium
           text-white", aria: { current: 'page' } do %> 
             <%= inline_svg 'icons/home', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Home
           <% end %>
-        </div>
-        <div class="space-y-1 px-2">
           <%= link_to destroy_user_session_path, method: :delete, class: "group flex items-center rounded-md
-          bg-violet-200 hover:bg-violet-300 px-2 py-2 text-base font-medium
+          hover:bg-violet-200 px-2 py-2 text-base font-medium
           text-white", aria: { current: 'page' } do %> 
             <%= inline_svg 'icons/logout', class: 'mr-4 h-6 w-6 flex-shrink-0 text-orange-500' %>
             Sign Out


### PR DESCRIPTION
Because:
The dashboard menu items weren't all contained within the wrapping div, causing the space between them to be too narrow

This commit:
  - Moves all menu items within the containing div