### PR TITLE
ProductModule story

### DIFF
--- a/app/models/core_product_module.rb
+++ b/app/models/core_product_module.rb
@@ -1,0 +1,2 @@
+class CoreProductModule < ProductModule
+end

--- a/app/models/elective_product_module.rb
+++ b/app/models/elective_product_module.rb
@@ -1,0 +1,2 @@
+class ElectiveProductModule < ProductModule
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,6 @@
 class Product < ApplicationRecord
   belongs_to :insurer
+  has_many :core_product_modules, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -1,0 +1,8 @@
+# This class is a parent to subclasses using STI. It should not be directly instantiated.
+
+class ProductModule < ApplicationRecord
+  belongs_to :product
+
+  validates :name, presence: true, uniqueness: { scope: %i[product_id], case_sensitive: false }
+  validates :type, presence: true
+end

--- a/db/migrate/20220307155950_create_product_modules.rb
+++ b/db/migrate/20220307155950_create_product_modules.rb
@@ -1,0 +1,12 @@
+class CreateProductModules < ActiveRecord::Migration[7.0]
+  def change
+    create_table :product_modules do |t|
+      t.string :name
+      t.references :product, null: false, foreign_key: true
+      t.string :type
+
+      t.timestamps
+    end
+    add_index :product_modules, %i[name product_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_17_104803) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_07_155950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_17_104803) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "product_modules", force: :cascade do |t|
+    t.string "name"
+    t.bigint "product_id", null: false
+    t.string "type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "product_id"], name: "index_product_modules_on_name_and_product_id", unique: true
+    t.index ["product_id"], name: "index_product_modules_on_product_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "name"
     t.bigint "insurer_id", null: false
@@ -82,5 +92,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_17_104803) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "product_modules", "products"
   add_foreign_key "products", "insurers"
 end

--- a/spec/factories/product_modules.rb
+++ b/spec/factories/product_modules.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :product_module do
+    name { 'MyString' }
+    product
+    type { '' }
+
+    trait :core_product_module do
+      type { 'CoreProductModule' }
+    end
+
+    trait :elective_product_module do
+      type { 'ElectiveProductModule' }
+    end
+
+    initialize_with { type.present? ? type.constantize.new : ProductModule.new }
+  end
+end

--- a/spec/models/core_product_module_spec.rb
+++ b/spec/models/core_product_module_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CoreProductModule, type: :model do
+  subject(:product_module) { create(:product_module, :core_product_module) }
+
+  it_behaves_like 'A ProductModule class'
+end

--- a/spec/models/elective_product_module_spec.rb
+++ b/spec/models/elective_product_module_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe ElectiveProductModule, type: :model do
+  subject(:product_module) { create(:product_module, :elective_product_module) }
+
+  it_behaves_like 'A ProductModule class'
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Product, type: :model do
   subject(:product) { create(:product) }
 
+  # Assocations
   it { expect(product).to belong_to(:insurer) }
+  it { expect(product).to have_many(:core_product_modules).dependent(:destroy)}
+
+  # Validations
   it { expect(product).to validate_presence_of :name }
 end

--- a/spec/support/shared_examples/product_module.rb
+++ b/spec/support/shared_examples/product_module.rb
@@ -1,0 +1,13 @@
+shared_examples 'A ProductModule class' do
+  it 'belongs to a product' do
+    expect(subject).to belong_to(:product)
+  end
+
+  it 'validates the name scoped to the product and not be case sensitive' do
+    expect(subject).to validate_uniqueness_of(:name).case_insensitive.scoped_to(%i[product_id])
+  end
+
+  it 'validates the presence of type' do
+    expect(subject).to validate_presence_of(:type)
+  end
+end


### PR DESCRIPTION
Because:
A ProductModule model is needed for modelling a group of benefits
within a Product

This commit:

* Create ProductModule model
* Create CoreProductModule subclass of ProductModule
* Create ElectiveProductModule subclass of ProductModule
* Create ProductModule shared rspec examples
* Add has_many core product modules to Product model
* Delete core and elective product module factories

Closes #204