### PR TITLE
LinkedProductModule story

### DIFF
--- a/app/models/core_product_module.rb
+++ b/app/models/core_product_module.rb
@@ -1,2 +1,4 @@
 class CoreProductModule < ProductModule
+  has_many :linked_product_modules, inverse_of: 'core_product_module', dependent: :destroy
+  has_many :elective_product_modules, through: :linked_product_modules
 end

--- a/app/models/elective_product_module.rb
+++ b/app/models/elective_product_module.rb
@@ -1,2 +1,4 @@
 class ElectiveProductModule < ProductModule
+  has_many :linked_product_modules, inverse_of: 'elective_product_module', dependent: :destroy
+  has_many :core_product_modules, through: :linked_product_modules
 end

--- a/app/models/linked_product_module.rb
+++ b/app/models/linked_product_module.rb
@@ -1,0 +1,6 @@
+class LinkedProductModule < ApplicationRecord
+  belongs_to :core_product_module, class_name: 'ProductModule'
+  belongs_to :elective_product_module, class_name: 'ProductModule'
+
+  validates :core_product_module_id, uniqueness: { scope: :elective_product_module_id }
+end

--- a/db/migrate/20220308215737_create_linked_product_modules.rb
+++ b/db/migrate/20220308215737_create_linked_product_modules.rb
@@ -1,0 +1,16 @@
+class CreateLinkedProductModules < ActiveRecord::Migration[7.0]
+  def change
+    create_table :linked_product_modules do |t|
+      t.integer :core_product_module_id, null: false
+      t.integer :elective_product_module_id, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :linked_product_modules, :product_modules, column: :core_product_module_id
+    add_foreign_key :linked_product_modules, :product_modules, column: :elective_product_module_id
+
+    add_index :linked_product_modules, %i[core_product_module_id elective_product_module_id],
+              unique: true, name: 'index_linked_product_modules_on_core_and_elective_modules'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_07_155950) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_08_215737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_07_155950) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "linked_product_modules", force: :cascade do |t|
+    t.integer "core_product_module_id", null: false
+    t.integer "elective_product_module_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["core_product_module_id", "elective_product_module_id"], name: "index_linked_product_modules_on_core_and_elective_modules", unique: true
   end
 
   create_table "product_modules", force: :cascade do |t|
@@ -92,6 +100,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_07_155950) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "linked_product_modules", "product_modules", column: "core_product_module_id"
+  add_foreign_key "linked_product_modules", "product_modules", column: "elective_product_module_id"
   add_foreign_key "product_modules", "products"
   add_foreign_key "products", "insurers"
 end

--- a/spec/factories/linked_product_modules.rb
+++ b/spec/factories/linked_product_modules.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :linked_product_module do
+    core_product_module { association :product_module, :core_product_module }
+    elective_product_module { association :product_module, :elective_product_module }
+  end
+end

--- a/spec/models/core_product_module_spec.rb
+++ b/spec/models/core_product_module_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe CoreProductModule, type: :model do
-  subject(:product_module) { create(:product_module, :core_product_module) }
+  subject(:core_product_module) { create(:product_module, :core_product_module) }
 
   it_behaves_like 'A ProductModule class'
+
+  # Associations
+  it { expect(core_product_module).to have_many(:linked_product_modules).dependent(:destroy) }
+  it { expect(core_product_module).to have_many(:elective_product_modules).through(:linked_product_modules) }
 end

--- a/spec/models/elective_product_module_spec.rb
+++ b/spec/models/elective_product_module_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe ElectiveProductModule, type: :model do
-  subject(:product_module) { create(:product_module, :elective_product_module) }
+  subject(:elective_product_module) { create(:product_module, :elective_product_module) }
 
   it_behaves_like 'A ProductModule class'
+
+  # Associations
+  it { expect(elective_product_module).to have_many(:linked_product_modules).dependent(:destroy) }
+  it { expect(elective_product_module).to have_many(:core_product_modules).through(:linked_product_modules) }
 end

--- a/spec/models/linked_product_module_spec.rb
+++ b/spec/models/linked_product_module_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe LinkedProductModule, type: :model do
+  subject(:linked_product_module) { create(:linked_product_module) }
+
+  # Assocations
+  it { expect(linked_product_module).to belong_to(:core_product_module).class_name('ProductModule') }
+  it { expect(linked_product_module).to belong_to(:elective_product_module).class_name('ProductModule') }
+
+  # Validations
+  it do
+    expect(linked_product_module).to(
+      validate_uniqueness_of(:core_product_module_id).scoped_to(:elective_product_module_id)
+    )
+  end
+end


### PR DESCRIPTION
Because:
We need to link CoreProductModules to ElectiveProductModules

This commit:

* Create LinkedProductModule model
* Add belongs_to assocations to LinkedProductModule
* Add has_many linked product module associations and through associations to CoreProductModule
* Add has_many assocations to elective_product_module
* Add uniqueness validation to scope core and elective module ids

closes #206