### PR TITLE
Fix: Product has many core product modules association

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,6 @@
 class Product < ApplicationRecord
   belongs_to :insurer
-  has_many :core_product_modules, dependent: :destroy
+  has_many :core_product_modules, class_name: 'ProductModule', dependent: :destroy
 
   validates :name, presence: true
 end


### PR DESCRIPTION
Because:
Deleting a product would throw an error because it wasn't also deleting referenced product_modules

This commit:

* Specify classname in Product has_many core_product_modules association