### PR TITLE
ProductModule Admin Story

### DIFF
--- a/app/controllers/admin/product_modules_controller.rb
+++ b/app/controllers/admin/product_modules_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class ProductModulesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/product_module_dashboard.rb
+++ b/app/dashboards/product_module_dashboard.rb
@@ -1,0 +1,75 @@
+require 'administrate/base_dashboard'
+
+class ProductModuleDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    product: Field::BelongsTo,
+    product_module_medical_benefits: Field::HasMany,
+    medical_benefits: Field::HasMany,
+    id: Field::Number,
+    name: Field::String,
+    type: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    product
+    product_module_medical_benefits
+    medical_benefits
+    id
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    product
+    product_module_medical_benefits
+    medical_benefits
+    id
+    name
+    type
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    product
+    product_module_medical_benefits
+    medical_benefits
+    name
+    type
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how product modules are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(product_module)
+  #   "ProductModule ##{product_module.id}"
+  # end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :products
       resources :core_product_modules
       resources :elective_product_modules
+      resources :product_modules
       resources :linked_product_modules
       resources :medical_benefits
       resources :product_module_medical_benefits


### PR DESCRIPTION
Because:
An error was being thrown without a product module dashboard view
when trying to view an admin page that showed a subclass of
ProductModule

This commit:

* Generate ProductModule admin dashboard
* Generate ProductModule admin controller
* Add admin route for ProductModule