### PR TITLE
Update admin dashboard attributes

### DIFF
--- a/app/dashboards/core_product_module_dashboard.rb
+++ b/app/dashboards/core_product_module_dashboard.rb
@@ -16,6 +16,9 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
     id: Field::Number,
     name: Field::String,
     type: Field::String,
+    category: Field::Select.with_options(searchable: false, collection: ->(field) {
+      field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    sum_assured: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -26,10 +29,10 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    product
-    product_module_medical_benefits
-    medical_benefits
-    linked_product_modules
+    name
+    sum_assured
+    category
+    id
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -43,6 +46,8 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
     id
     name
     type
+    sum_assured
+    category
     created_at
     updated_at
   ].freeze
@@ -58,6 +63,8 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
     elective_product_modules
     name
     type
+    sum_assured
+    category
   ].freeze
 
   # COLLECTION_FILTERS
@@ -75,7 +82,7 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how core product modules are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(core_product_module)
-  #   "CoreProductModule ##{core_product_module.id}"
-  # end
+  def display_resource(core_product_module)
+    core_product_module.name
+  end
 end

--- a/app/dashboards/elective_product_module_dashboard.rb
+++ b/app/dashboards/elective_product_module_dashboard.rb
@@ -16,6 +16,9 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
     id: Field::Number,
     name: Field::String,
     type: Field::String,
+    category: Field::Select.with_options(searchable: false, collection: ->(field) {
+      field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    sum_assured: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -26,10 +29,10 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    product
-    product_module_medical_benefits
-    medical_benefits
-    linked_product_modules
+    name
+    sum_assured
+    category
+    id
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -43,6 +46,8 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
     id
     name
     type
+    sum_assured
+    category
     created_at
     updated_at
   ].freeze
@@ -58,6 +63,8 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
     core_product_modules
     name
     type
+    sum_assured
+    category
   ].freeze
 
   # COLLECTION_FILTERS
@@ -75,7 +82,7 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how elective product modules are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(elective_product_module)
-  #   "ElectiveProductModule ##{elective_product_module.id}"
-  # end
+  def display_resource(elective_product_module)
+    elective_product_module.name
+  end
 end

--- a/app/dashboards/insurer_dashboard.rb
+++ b/app/dashboards/insurer_dashboard.rb
@@ -10,6 +10,7 @@ class InsurerDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
+    logo_name: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -22,7 +23,7 @@ class InsurerDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     name
-    created_at
+    logo_name
     updated_at
   ].freeze
 
@@ -31,7 +32,7 @@ class InsurerDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     name
-    created_at
+    logo_name
     updated_at
   ].freeze
 
@@ -40,6 +41,7 @@ class InsurerDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     name
+    logo_name
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/dashboards/linked_product_module_dashboard.rb
+++ b/app/dashboards/linked_product_module_dashboard.rb
@@ -60,7 +60,7 @@ class LinkedProductModuleDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how linked product modules are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(linked_product_module)
-  #   "LinkedProductModule ##{linked_product_module.id}"
-  # end
+  def display_resource(linked_product_module)
+    "#{linked_product_module.core_product_module.name} : #{linked_product_module.elective_product_module.name}"
+  end
 end

--- a/app/dashboards/medical_benefit_dashboard.rb
+++ b/app/dashboards/medical_benefit_dashboard.rb
@@ -61,7 +61,7 @@ class MedicalBenefitDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how medical benefits are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(medical_benefit)
-  #   "MedicalBenefit ##{medical_benefit.id}"
-  # end
+  def display_resource(medical_benefit)
+    medical_benefit.name
+  end
 end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -24,7 +24,7 @@ class ProductDashboard < Administrate::BaseDashboard
     insurer
     id
     name
-    created_at
+    updated_at
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/dashboards/product_module_dashboard.rb
+++ b/app/dashboards/product_module_dashboard.rb
@@ -30,7 +30,7 @@ class ProductModuleDashboard < Administrate::BaseDashboard
     name
     type
     sum_assured
-    id
+    category
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -76,7 +76,7 @@ class ProductModuleDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how product modules are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(product_module)
-  #   "ProductModule ##{product_module.id}"
-  # end
+  def display_resource(product_module)
+    product_module.name
+  end
 end

--- a/app/dashboards/product_module_medical_benefit_dashboard.rb
+++ b/app/dashboards/product_module_medical_benefit_dashboard.rb
@@ -27,8 +27,8 @@ class ProductModuleMedicalBenefitDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     product_module
     medical_benefit
-    id
     benefit_limit
+    benefit_limit_status
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -70,7 +70,7 @@ class ProductModuleMedicalBenefitDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how product module medical benefits are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(product_module_medical_benefit)
-  #   "ProductModuleMedicalBenefit ##{product_module_medical_benefit.id}"
-  # end
+  def display_resource(product_module_medical_benefit)
+    "#{product_module_medical_benefit.product_module.name} : #{product_module_medical_benefit.medical_benefit.name}"
+  end
 end


### PR DESCRIPTION
Because:
Admin dashboards either weren't showing attributes or were showing some
models by their ruby object name

This commit:

* Add logo name to insurer admin dashboard
* change created_at for updated_at on product admin dashboard collection attributes
* Update attributes for product module admin dashboard
* Update attributes for linked product modules admin dashboard
* Update attributes for medical benefit admin dashboard
* Update attributes for product module medical benefit admin dashboard
* Show all models by name