### PR TITLE
Health comparison show

### DIFF
--- a/app/assets/images/icons/check_outline.svg
+++ b/app/assets/images/icons/check_outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+</svg>

--- a/app/assets/images/icons/check_outline.svg
+++ b/app/assets/images/icons/check_outline.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+<svg data-test-id="check-outline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
   <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
 </svg>

--- a/app/assets/images/icons/x_outline.svg
+++ b/app/assets/images/icons/x_outline.svg
@@ -1,0 +1,3 @@
+<svg data-test-id="x-outline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+</svg>

--- a/app/components/medical_benefit_coverage_icon_component.html.erb
+++ b/app/components/medical_benefit_coverage_icon_component.html.erb
@@ -1,0 +1,1 @@
+<%= inline_svg "icons/#{icon_name}.svg", class: "h-6 w-6 #{icon_colour}" %>

--- a/app/components/medical_benefit_coverage_icon_component.rb
+++ b/app/components/medical_benefit_coverage_icon_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class MedicalBenefitCoverageIconComponent < ViewComponent::Base
+  def initialize(status:)
+    @status = status
+  end
+
+  private
+
+  attr_reader :status
+
+  def icon_name
+    coverage_icons.fetch(status)
+  end
+
+  def coverage_icons
+    {
+      "paid_in_full" => "check_circle_outline",
+      "capped" => "check_outline",
+      "not_covered" => "x_outline"
+    }
+  end
+
+  def icon_colour
+      coverage_colours.fetch(status)
+  end
+
+  def coverage_colours
+    {
+      "paid_in_full" => "text-green-600",
+      "capped" => "text-green-600",
+      "not_covered" => "text-red-600"
+    }
+  end
+end

--- a/app/components/tab_menu_component.html.erb
+++ b/app/components/tab_menu_component.html.erb
@@ -1,0 +1,20 @@
+<div>
+  <div class="sm:hidden">
+    <label for="tabs" class="sr-only">Select a tab</label>
+    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
+    <select id="tabs" name="tabs" class="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+      <% iterator.each do |element| %>
+        <option><%= element.titleize %></option>
+      <% end %>
+    </select>
+  </div>
+  <div class="hidden sm:block">
+    <div class="border-b border-gray-200">
+      <nav class="-mb-px flex flex-wrap space-x-4" aria-label="Tabs">
+        <% iterator.each do |element| %>
+          <a href="<%= health_plan_comparisons_path(tab: element) %>" class="<%= tab_classes(element) %> whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" data-test-id="<%= element %>-tab"><%= element.titleize %> </a>
+        <% end %>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/components/tab_menu_component.rb
+++ b/app/components/tab_menu_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class TabMenuComponent < ViewComponent::Base
+  def initialize(iterator:, selected_tab:)
+    @iterator = iterator
+    @selected_tab = selected_tab
+  end
+
+  private
+
+  attr_reader :iterator, :selected_tab
+  
+  def tab_classes(category)
+    if selected_tab == category
+      "border-indigo-500 text-indigo-600"
+    else
+      "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+    end
+  end
+end

--- a/app/controllers/health_plan_comparisons_controller.rb
+++ b/app/controllers/health_plan_comparisons_controller.rb
@@ -6,6 +6,13 @@ class HealthPlanComparisonsController < ApplicationController
     @comparison_health_policies = comparison_health_insurance_policies
   end
 
+  def show
+    @comparison_health_policies = comparison_health_insurance_policies
+    @benefit_categories = MedicalBenefit.categories.keys
+    @grouped_benefits = MedicalBenefit.all.group_by(&:category)
+    @selected_tab = params[:tab] || "inpatient"
+  end
+
   private
 
   def reset_comparison_health_policies_session

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,2 +1,0 @@
-module DashboardsHelper
-end

--- a/app/helpers/health_plan_comparisons_helper.rb
+++ b/app/helpers/health_plan_comparisons_helper.rb
@@ -1,2 +1,0 @@
-module HealthPlanComparisonsHelper
-end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("class-toggle", ClassToggleController)
 import ElementController from "./element_controller.js"
 application.register("element", ElementController)
 
+import RevealController from "./reveal_controller.js"
+application.register("reveal", RevealController)
+
 import TransitionController from "./transition_controller.js"
 application.register("transition", TransitionController)

--- a/app/javascript/controllers/reveal_controller.js
+++ b/app/javascript/controllers/reveal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="reveal"
+export default class extends Controller {
+  static targets = ['content'];
+
+  toggle(e) {
+    e.preventDefault();
+    const category = e.target.dataset.category;
+
+    this.contentTargets.forEach(target => {
+      if (target.dataset.category === category) {
+        target.classList.remove('hidden');
+      } else {
+        target.classList.add('hidden');
+      }
+    });
+  }
+}

--- a/app/nulls/null_product_module_medical_benefit.rb
+++ b/app/nulls/null_product_module_medical_benefit.rb
@@ -1,0 +1,5 @@
+class NullProductModuleMedicalBenefit
+  def benefit_limit_status
+    "not_covered"
+  end
+end

--- a/app/views/health_plan_comparisons/new.html.erb
+++ b/app/views/health_plan_comparisons/new.html.erb
@@ -8,6 +8,12 @@
           <%= render(HealthPolicyComparisonSelectionListComponent.with_collection(@comparison_health_policies)) %>
         </ul>
       </div>
+      <div class="flex justify-center">
+        <% if @comparison_health_policies.any? %>
+          <%= link_to "Compare", health_plan_comparisons_path, class: "inline-flex items-center px-1 py-1 mt-2 border border-transparent text-sm justify-center font-medium rounded-md 
+shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 w-11/12", data: { test_id: "compare-btn" } %>
+        <% end %>
+      </div>
     </section>
     <!-- Secondary column (hidden on smaller screens) -->
     <aside class="hidden lg:block lg:flex-shrink-0 lg:order-first">

--- a/app/views/health_plan_comparisons/show.html.erb
+++ b/app/views/health_plan_comparisons/show.html.erb
@@ -1,0 +1,49 @@
+<%= render(DashboardMenuComponent.new) do %>
+  <main class="min-w-0 flex-1 border-t border-gray-200 lg:flex">
+    <!-- Primary column -->
+    <turbo-frame id="benefit-comparison">
+      <section aria-labelledby="primary-heading" class="min-w-0 flex-1 h-full flex flex-col overflow-y-auto lg:order-first">
+        <h1 id="primary-heading" class="sr-only">Health Policy Comparison</h1>
+        <!-- Tab Menu -->
+        <%= render TabMenuComponent.new(iterator: @benefit_categories, selected_tab: @selected_tab) %>
+        <div class="p-4">
+          <table class="table-fixed divide-y divide-gray-300" id="<%= @selected_tab %>-comparison-table">
+            <thead>
+              <tr>
+                <th class="w-52"></th>
+                <% @comparison_health_policies.each do |policy| %>
+                  <th scope="col" class="w-52 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 md:pl-0">
+                    <div><%= policy.insurer.name %></div>
+                    <div><%= policy.product.name %></div>
+                    <div><%= policy.product_module_names.join(" + ") %></div>
+                  </th>
+                <% end %>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+              <% @grouped_benefits[@selected_tab]&.each do |benefit| %>
+                <tr>
+                  <td class="w-52 py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 md:pl-0"><%= benefit.name %></td>
+                  <% @comparison_health_policies.each do |policy| %>
+                    <td class="w-52 py-4 px-3 text-sm text-gray-500">
+                      <%= render MedicalBenefitCoverageIconComponent.new(status: policy.product_module_medical_benefit(benefit.id).benefit_limit_status) %>
+                    </td>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </turbo-frame>
+    <!-- Secondary column (hidden on smaller screens) -->
+    <aside class="hidden lg:block lg:flex-shrink-0 lg:order-last">
+      <div class="h-full relative flex flex-col w-64 border-r border-gray-200 overflow-y-auto">
+        <div class="sm:mx-auto sm:w-full sm:max-w-md">
+          <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          </div>
+        </div>
+      </div>
+    </aside>
+  </main>
+<% end %>

--- a/spec/components/medical_benefit_coverage_icon_component_spec.rb
+++ b/spec/components/medical_benefit_coverage_icon_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MedicalBenefitCoverageIconComponent, type: :component do
+  subject(:icon) { described_class.new(status: status) }
+
+  context "with a status of paid_in_full" do
+    let(:status) { "paid_in_full" }
+
+    it "renders the check circle icon" do
+      render_inline(icon)
+
+      expect(page).to have_css "svg[data-test-id='check-circle-outline']"
+    end
+
+    it "renders it in green" do
+      render_inline(icon)
+
+      expect(page).to have_css ".text-green-600"
+    end
+  end
+
+  context "with a status of capped" do
+    let(:status) { "capped" }
+
+    it "renders the check icon" do
+      render_inline(icon)
+
+      expect(page).to have_css "svg[data-test-id='check-outline']"
+    end
+
+    it "renders it in green" do
+      render_inline(icon)
+
+      expect(page).to have_css ".text-green-600"
+    end
+  end
+
+  context "with a status of not_covered" do
+    let(:status) { "not_covered" }
+
+    it "renders the x icon" do
+      render_inline(icon)
+
+      expect(page).to have_css "svg[data-test-id='x-outline']"
+    end
+
+    it "renders it in red" do
+      render_inline(icon)
+
+      expect(page).to have_css ".text-red-600"
+    end
+  end
+end

--- a/spec/models/health_insurance_policy_spec.rb
+++ b/spec/models/health_insurance_policy_spec.rb
@@ -67,4 +67,88 @@ RSpec.describe HealthInsurancePolicy, type: :model do
       expect(described_class.new(params).id).to eq uuid
     end
   end
+
+  describe "#product_module_benefit_benefit" do
+    subject(:health_insurance_policy) { described_class.new(params) }
+
+    let(:params) do
+      {
+        "insurer_id" => 1,
+        "product_id" => 2,
+        "core_product_module_id" => 1,
+        "elective_product_module_ids" => [2],
+        "id" => "1234"
+      }
+    end
+    let(:product_module_medical_benefit) { ProductModuleMedicalBenefit.find(1) }
+
+    before do
+      create(:insurer, id: 1) do |insurer|
+        create(:product, id: 2, insurer: insurer) do |product|
+          create(:product_module, :core_product_module, id: 1, product: product) do |core_product_module|
+            create(:medical_benefit, id: 1) do |medical_benefit|
+              create(:product_module_medical_benefit, id: 1,
+                                                      product_module: core_product_module,
+                                                      medical_benefit: medical_benefit)
+            end
+            create(:product_module, :elective_product_module, id: 2, name: "Evacuation", 
+product: product) do |elective_product_module|
+              create(:linked_product_module, core_product_module: core_product_module,
+                                             elective_product_module: elective_product_module)
+            end
+          end
+        end
+      end
+    end
+
+    context "when the health insurance policy does cover the benefit" do
+      it "returns the matching ProductModuleMedicalBenefit" do
+        expect(health_insurance_policy.product_module_medical_benefit(1)).to eq product_module_medical_benefit
+      end
+    end
+
+    context "when the health insurance policy does not cover the benefit" do
+      it "returns a NullProductModuleMedicalBenefit" do
+        expect(health_insurance_policy.product_module_medical_benefit(3)).to be_a NullProductModuleMedicalBenefit
+      end
+    end
+  end
+
+  describe "#product_module_names" do
+    subject(:health_insurance_policy) { described_class.new(params) }
+
+    let(:params) do
+      {
+        "insurer_id" => 1,
+        "product_id" => 2,
+        "core_product_module_id" => 1,
+        "elective_product_module_ids" => [2],
+        "id" => "1234"
+      }
+    end
+    let(:product_module_medical_benefit) { ProductModuleMedicalBenefit.find(1) }
+
+    before do
+      create(:insurer, id: 1) do |insurer|
+        create(:product, id: 2, insurer: insurer) do |product|
+          create(:product_module, :core_product_module, id: 1, name: "Gold", product: product) do |core_product_module|
+            create(:medical_benefit, id: 1) do |medical_benefit|
+              create(:product_module_medical_benefit, id: 1,
+                                                      product_module: core_product_module,
+                                                      medical_benefit: medical_benefit)
+            end
+            create(:product_module, :elective_product_module, id: 2, name: "Evacuation", 
+product: product) do |elective_product_module|
+              create(:linked_product_module, core_product_module: core_product_module,
+                                             elective_product_module: elective_product_module)
+            end
+          end
+        end
+      end
+    end
+
+    it "maps the product module names into an array" do
+      expect(health_insurance_policy.product_module_names).to eq ["Gold", "Evacuation"]
+    end
+  end
 end

--- a/spec/nulls/null_product_module_medical_benefit_spec.rb
+++ b/spec/nulls/null_product_module_medical_benefit_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe NullProductModuleMedicalBenefit do
+  subject(:null_product_module_medical_benefit) { described_class.new }
+  
+  let(:status) { "not_covered" }
+
+  describe "#benefit_limit_status" do
+    it "returns not_covered" do
+      expect(null_product_module_medical_benefit.benefit_limit_status).to eq status
+    end
+  end
+end

--- a/spec/system/health_insurance_comparison_show_spec.rb
+++ b/spec/system/health_insurance_comparison_show_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe "Health Insurance Comparison Show View" do
+  let(:user) { create(:user, email: "dummy@libra.financial") }
+
+  # rubocop:disable Layout/LineLength
+  before do
+    create(:medical_benefit, name: "Hospital Accomodation", category: "inpatient")
+    create(:medical_benefit, name: "Intensive Care", category: "inpatient")
+    create(:medical_benefit, name: "Mental Health Treatment", category: "inpatient")
+    create(:medical_benefit, name: "Outpatient Surgical Operations", category: "outpatient")
+    create(:medical_benefit, name: "Qualified Nurse Treatment", category: "outpatient")
+    create(:medical_benefit, name: "Physiotherapy", category: "therapists")
+    create(:medical_benefit, name: "Osteopathy", category: "therapists")
+    create(:medical_benefit, name: "Evacuation Transport Costs to Nearest Country", 
+category: "evacuation_and_repatriation")
+    create(:medical_benefit, name: "Accompanying Person Travel Costs", category: "evacuation_and_repatriation")
+    create(:medical_benefit, name: "Evacuation Return Journey", category: "evacuation_and_repatriation")
+    create(:medical_benefit, name: "Repatriation of Mortal Remains", category: "evacuation_and_repatriation")
+    
+    create(:insurer, name: "BUPA Global") do |insurer|
+      create(:product, name: "Lifeline", insurer: insurer) do |product|
+        create(:product_module, :core_product_module, product: product, name: "Gold", sum_assured: "Unlimited", 
+category: :core) do |product_module|
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Hospital Accomodation"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Intensive Care"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Mental Health Treatment"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Outpatient Surgical Operations"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Qualified Nurse Treatment"),
+                                                  benefit_limit: "Paid in full for up to 15 visits each membership year",
+                                                  benefit_limit_status: "capped",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Physiotherapy"),
+                                                  benefit_limit: "Paid in full for up to 30 visits each membership year",
+                                                  benefit_limit_status: "capped",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Osteopathy"),
+                                                  benefit_limit: "Paid in full for up to 30 visits each membership year",
+                                                  benefit_limit_status: "capped",
+                                                  product_module: product_module)
+        end
+        create(:product_module, :elective_product_module, product: product, name: "Evacuation", 
+sum_assured: "Within Overall Limit", category: :evacuation_and_repatriation) do |product_module|
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Evacuation Transport Costs to Nearest Country"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Accompanying Person Travel Costs"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Evacuation Return Journey"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+          create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Repatriation of Mortal Remains"),
+                                                  benefit_limit: "Paid in full",
+                                                  benefit_limit_status: "paid_in_full",
+                                                  product_module: product_module)
+        end
+        create(:linked_product_module, core_product_module: ProductModule.find_by(name: "Gold"),
+                                       elective_product_module: ProductModule.find_by(name: "Evacuation"))
+      end
+    end
+    # rubocop:enable Layout/LineLength
+
+    sign_in(user)
+    visit root_path
+    find(:test_id, "health-comparison-link").click
+
+    find(:test_id, "insurer-select-field").select("BUPA Global")
+    find(:test_id, "product-select-field").select("Lifeline")
+    page.choose("Gold")
+    page.choose("Evacuation")
+    find(:test_id, "submit-btn").click
+    find(:test_id, "compare-btn").click
+  end
+
+  context "with the intitial view" do
+    it "displays the comparison table of medical benefits by the default category of inpatient" do
+      expect(page).to have_table("inpatient-comparison-table")
+    end
+
+    it "displays the inpatient benefit names" do
+      expect(page).to have_table("inpatient-comparison-table", with_cols:
+        [
+          ["Hospital Accomodation", "Intensive Care", "Mental Health Treatment"]
+        ])
+    end
+
+    it "displays the correct icon for the benefit coverage of the selected product to compare" do
+      expect(page).to have_selector("svg[data-test-id='check-circle-outline']", count: 3)
+    end
+
+    it "does not display other categories tables" do
+      expect(page).not_to have_table("outpatient-comparison-table")
+    end
+  end
+
+  context "when selecting a different tab" do
+    before do
+      find(:test_id, "outpatient-tab").click
+    end
+
+    it "displays the benefit comparison table for the selected tab" do
+      expect(page).to have_table("outpatient-comparison-table")
+    end
+
+    it "doesn't display the default table" do
+      expect(page).not_to have_table("inpatient-comparison-table")
+    end
+  end
+end


### PR DESCRIPTION
Because
Users need to be able to compare the medical benefits of the health
insurance plans they have selected

This commit:

* Add x outline svg
* Remove unnecessary helper files
* Add medical coverage benefit icon helper method
* Create NullProductModuleMedicalBenefit
* Add test ids to icons used in tests
* Create MedicalBenefitCoverageIconComponent
* Create reveal stimulus controller
* Remove coverage_icon method from ApplicationHelper
* Create Tab Menu Component
* Add show method to comparison controller
* Eager load product module medical benefits and medical benefits of health insurance policy
* Add health insurance comparison show view
* Add system tests for behaviour

closes #329 