### PR TITLE
Specify file extention for main logo

### DIFF
--- a/app/components/dashboard_menu_component.html.erb
+++ b/app/components/dashboard_menu_component.html.erb
@@ -77,7 +77,7 @@
     <!-- Sidebar component -->
     <div class="flex flex-grow flex-col overflow-y-auto bg-violet-50 pt-5 pb-4">
       <div class="flex flex-shrink-0 items-center px-4">
-        <%= image_tag 'logo_white_text', alt: 'Logo' %>
+        <%= image_tag 'logo_white_text.png', alt: 'Logo' %>
       </div>
       <nav
         class="mt-5 flex flex-1 flex-col divide-y divide-cyan-800 overflow-y-auto"


### PR DESCRIPTION
Because
Heroku cannot locate the main site logo in images

This commit:

* Specify file extension for main logo image on render