### PR TITLE
Add export function to administrate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "redis", "~> 4.0"
 gem "bootsnap", ">= 1.4.4", require: false
 
 gem "administrate", github: "n-studio/administrate", branch: "compile-assets"
+gem "administrate_exportable", "~> 0.6.0"
 gem "cssbundling-rails"
 gem "devise", "~> 4.8"
 gem "devise_invitable", "~> 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,11 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    administrate_exportable (0.6.0)
+      actionview (>= 5.2.2.1)
+      administrate (>= 0.17.0)
+      rails (>= 4.2)
+      railties (>= 5.2.2.1)
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
@@ -329,6 +334,7 @@ PLATFORMS
 
 DEPENDENCIES
   administrate!
+  administrate_exportable (~> 0.6.0)
   bootsnap (>= 1.4.4)
   byebug
   capybara

--- a/app/controllers/admin/medical_benefits_controller.rb
+++ b/app/controllers/admin/medical_benefits_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class MedicalBenefitsController < Admin::ApplicationController
+    include AdministrateExportable::Exporter
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   namespace :admin do
       resources :users
@@ -9,7 +10,9 @@ Rails.application.routes.draw do
       resources :elective_product_modules
       resources :product_modules
       resources :linked_product_modules
-      resources :medical_benefits
+      resources :medical_benefits do
+        get :export, on: :collection
+      end
       resources :product_module_medical_benefits
 
       root to: "users#index"
@@ -31,3 +34,4 @@ Rails.application.routes.draw do
     resources :health_insurance_policies, only: [:create, :destroy]
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Because
The medical benefits need to be exportable by an admin user

This commit:
* Add administrate_exportable gem
* Include export module into admin medical benefit controller
* Add export link to admin route for medical benefit