### PR TITLE
Add svg file extension to bin icon

### DIFF
--- a/app/components/health_policy_comparison_selection_list_component.html.erb
+++ b/app/components/health_policy_comparison_selection_list_component.html.erb
@@ -22,7 +22,7 @@
     </div>
     <div>
       <%= link_to comparisons_health_insurance_policy_path(id: @health_insurance_policy.id), data: { turbo_method: :delete } do %>
-        <%= inline_svg('icons/trash_outline', class: 'h-6 w-6 text-gray-700') %>
+        <%= inline_svg('icons/trash_outline.svg', class: 'h-6 w-6 text-gray-700') %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Because:
The bin icon was not showing up in the health insurance comparison selection list

This commit:
* specify svg extension for bin icon