### PR TITLE
remove setting capybara host

### DIFF
--- a/spec/support/better_rails_system_tests.rb
+++ b/spec/support/better_rails_system_tests.rb
@@ -17,15 +17,6 @@ end
 RSpec.configure do |config|
   config.include BetterRailsSystemTests, type: :system
 
-  # Make urls in mailers contain the correct server host.
-  # It's required for testing links in emails (e.g., via capybara-email).
-  config.around(:each, type: :system) do |ex|
-    was_host = Rails.application.default_url_options[:host]
-    Rails.application.default_url_options[:host] = Capybara.server_host
-    ex.run
-    Rails.application.default_url_options[:host] = was_host
-  end
-
   # Make sure this hook runs before others
   config.prepend_before(:each, type: :system) do
     # Use JS driver always


### PR DESCRIPTION
Because
It was causing flaky tests

This commit:
* Remove setting capybara host for mailers