### PR TITLE
Health Comparison Spreadsheet export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem "bootsnap", ">= 1.4.4", require: false
 
 gem "administrate", github: "n-studio/administrate", branch: "compile-assets"
 gem "administrate_exportable", "~> 0.6.0"
+gem "axlsx_styler", "~> 1.1"
+gem "caxlsx", "~> 3.2"
+gem "caxlsx_rails", "~> 0.6.3"
 gem "cssbundling-rails"
 gem "devise", "~> 4.8"
 gem "devise_invitable", "~> 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       rails (>= 4.2)
       railties (>= 5.2.2.1)
     ast (2.4.2)
+    axlsx_styler (1.1.0)
+      activesupport (>= 3.1)
+      caxlsx (>= 2.0.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.12.0)
@@ -100,6 +103,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    caxlsx (3.2.0)
+      htmlentities (~> 4.3, >= 4.3.4)
+      marcel (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
+    caxlsx_rails (0.6.3)
+      actionpack (>= 3.1)
+      caxlsx (>= 3.0)
     cliver (0.3.2)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -134,6 +145,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    htmlentities (4.3.4)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     imagen (0.1.8)
@@ -280,6 +292,7 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
     rugged (1.2.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
@@ -337,9 +350,12 @@ PLATFORMS
 DEPENDENCIES
   administrate!
   administrate_exportable (~> 0.6.0)
+  axlsx_styler (~> 1.1)
   bootsnap (>= 1.4.4)
   byebug
   capybara
+  caxlsx (~> 3.2)
+  caxlsx_rails (~> 0.6.3)
   cssbundling-rails
   cuprite
   devise (~> 4.8)

--- a/app/assets/images/icons/excel-logo.svg
+++ b/app/assets/images/icons/excel-logo.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Livello_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 2289.75 2130"
+	 enable-background="new 0 0 2289.75 2130" xml:space="preserve">
+<metadata>
+	<sfw  xmlns="&ns_sfw;">
+		<slices></slices>
+		<sliceSourceBounds  bottomLeftOrigin="true" height="2130" width="2289.75" x="-1147.5" y="-1041"></sliceSourceBounds>
+	</sfw>
+</metadata>
+<path fill="#185C37" d="M1437.75,1011.75L532.5,852v1180.393c0,53.907,43.7,97.607,97.607,97.607l0,0h1562.036
+	c53.907,0,97.607-43.7,97.607-97.607l0,0V1597.5L1437.75,1011.75z"/>
+<path fill="#21A366" d="M1437.75,0H630.107C576.2,0,532.5,43.7,532.5,97.607c0,0,0,0,0,0V532.5l905.25,532.5L1917,1224.75
+	L2289.75,1065V532.5L1437.75,0z"/>
+<path fill="#107C41" d="M532.5,532.5h905.25V1065H532.5V532.5z"/>
+<path opacity="0.1" enable-background="new    " d="M1180.393,426H532.5v1331.25h647.893c53.834-0.175,97.432-43.773,97.607-97.607
+	V523.607C1277.825,469.773,1234.227,426.175,1180.393,426z"/>
+<path opacity="0.2" enable-background="new    " d="M1127.143,479.25H532.5V1810.5h594.643
+	c53.834-0.175,97.432-43.773,97.607-97.607V576.857C1224.575,523.023,1180.977,479.425,1127.143,479.25z"/>
+<path opacity="0.2" enable-background="new    " d="M1127.143,479.25H532.5V1704h594.643c53.834-0.175,97.432-43.773,97.607-97.607
+	V576.857C1224.575,523.023,1180.977,479.425,1127.143,479.25z"/>
+<path opacity="0.2" enable-background="new    " d="M1073.893,479.25H532.5V1704h541.393c53.834-0.175,97.432-43.773,97.607-97.607
+	V576.857C1171.325,523.023,1127.727,479.425,1073.893,479.25z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="203.5132" y1="1729.0183" x2="967.9868" y2="404.9817" gradientTransform="matrix(1 0 0 -1 0 2132)">
+	<stop  offset="0" style="stop-color:#18884F"/>
+	<stop  offset="0.5" style="stop-color:#117E43"/>
+	<stop  offset="1" style="stop-color:#0B6631"/>
+</linearGradient>
+<path fill="url(#SVGID_1_)" d="M97.607,479.25h976.285c53.907,0,97.607,43.7,97.607,97.607v976.285
+	c0,53.907-43.7,97.607-97.607,97.607H97.607C43.7,1650.75,0,1607.05,0,1553.143V576.857C0,522.95,43.7,479.25,97.607,479.25z"/>
+<path fill="#FFFFFF" d="M302.3,1382.264l205.332-318.169L319.5,747.683h151.336l102.666,202.35
+	c9.479,19.223,15.975,33.494,19.49,42.919h1.331c6.745-15.336,13.845-30.228,21.3-44.677L725.371,747.79h138.929l-192.925,314.548
+	L869.2,1382.263H721.378L602.79,1160.158c-5.586-9.45-10.326-19.376-14.164-29.66h-1.757c-3.474,10.075-8.083,19.722-13.739,28.755
+	l-122.102,223.011H302.3z"/>
+<path fill="#33C481" d="M2192.143,0H1437.75v532.5h852V97.607C2289.75,43.7,2246.05,0,2192.143,0L2192.143,0z"/>
+<path fill="#107C41" d="M1437.75,1065h852v532.5h-852V1065z"/>
+</svg>

--- a/app/controllers/health_plan_comparisons_controller.rb
+++ b/app/controllers/health_plan_comparisons_controller.rb
@@ -11,6 +11,13 @@ class HealthPlanComparisonsController < ApplicationController
     @benefit_categories = MedicalBenefit.categories.keys
     @grouped_benefits = MedicalBenefit.all.group_by(&:category)
     @selected_tab = params[:tab] || "inpatient"
+
+    respond_to do |format|
+      format.html
+      format.xlsx do
+        response.headers["Content-Disposition"] = 'attachment; filename="comparison.xlsx"'
+      end
+    end
   end
 
   private

--- a/app/models/health_insurance_policy.rb
+++ b/app/models/health_insurance_policy.rb
@@ -79,4 +79,8 @@ class HealthInsurancePolicy
     match = product_module_medical_benefits.find { |medical_benefit| medical_benefit.medical_benefit.id == benefit_id }
     match || NullProductModuleMedicalBenefit.new
   end
+
+  def overall_sum_assured
+    core_product_module.sum_assured
+  end
 end

--- a/app/nulls/null_product_module_medical_benefit.rb
+++ b/app/nulls/null_product_module_medical_benefit.rb
@@ -2,4 +2,8 @@ class NullProductModuleMedicalBenefit
   def benefit_limit_status
     "not_covered"
   end
+
+  def benefit_limit
+    "Not Covered"
+  end
 end

--- a/app/views/health_plan_comparisons/show.html.erb
+++ b/app/views/health_plan_comparisons/show.html.erb
@@ -41,6 +41,12 @@
       <div class="h-full relative flex flex-col w-64 border-r border-gray-200 overflow-y-auto">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
           <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+            <div class="flex flex-col gap-x-2 items-center">
+              <h3>Export</h3>
+              <%= link_to health_plan_comparisons_path(format: :xlsx), target: '_blank' do %>
+                <%= inline_svg "icons/excel-logo.svg", class: "h-8 w-8" %>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/health_plan_comparisons/show.xlsx.axlsx
+++ b/app/views/health_plan_comparisons/show.xlsx.axlsx
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+wb = xlsx_package.workbook
+
+# styles
+center_text = { alignment: { horizontal: :center, vertical: :center, wrap_text: true } }
+
+benefit_coverage_styles = {
+  "paid_in_full" => wb.styles.add_style(bg_color: "7dcea0"),
+  "capped" => wb.styles.add_style(bg_color: "f0b27a"),
+  "not_covered" => wb.styles.add_style(bg_color: "ec7063")
+}
+
+benefit_category_styles = {
+  "inpatient" => wb.styles.add_style(bg_color: "b7ede6"),
+  "outpatient" => wb.styles.add_style(bg_color: "b7d7ed"),
+  "therapists" => wb.styles.add_style(bg_color: "b7bced"),
+  "medicines_and_appliances" => wb.styles.add_style(bg_color: "d3da6a"),
+  "wellness" => wb.styles.add_style(bg_color: "daa76a"),
+  "evacuation_and_repatriation" => wb.styles.add_style(bg_color: "e29bd1"),
+  "maternity" => wb.styles.add_style(bg_color: "a2b6a9"),
+  "dental" => wb.styles.add_style(bg_color: "c9e1fa"),
+  "optical" => wb.styles.add_style(bg_color: "fae7c9"),
+  "additional" => wb.styles.add_style(bg_color: "cac9fa")
+}
+
+comparison_product_headers = {
+  insurer_names: @comparison_health_policies.map { _1.insurer.name },
+  product_names:@comparison_health_policies.map{ _1.product.name },
+  product_modules_names: @comparison_health_policies.map { _1.product_module_names.join(" + ") },
+  overall_sums_assured: @comparison_health_policies.map(&:overall_sum_assured)
+}
+
+# rubocop:disable Metrics/BlockLength
+@benefit_categories.each do |category|
+  next unless @grouped_benefits[category]
+  wb.add_worksheet(name: category.titleize) do |sheet|
+    # headers
+    sheet.add_row [nil, nil, *comparison_product_headers.fetch(:insurer_names)]
+    sheet.add_row [nil, nil, *comparison_product_headers.fetch(:product_names)]
+    sheet.add_row [nil, nil, *comparison_product_headers.fetch(:product_modules_names)]
+    sheet.add_row [nil, nil, *comparison_product_headers.fetch(:overall_sums_assured)]
+
+    # benefits
+    category_colour = benefit_category_styles[category]
+    category_length = @grouped_benefits[category].length
+
+    @grouped_benefits[category].each do |benefit|
+      row_styles = [category_colour, category_colour]
+
+      selected_product_benefits = @comparison_health_policies.map do |policy|
+        matched_benefit = policy.product_module_medical_benefit(benefit.id)
+
+        row_styles << benefit_coverage_styles[matched_benefit.benefit_limit_status]
+
+        matched_benefit.benefit_limit
+      end
+
+      sheet.add_row [category.titleize, benefit.name.titleize, *selected_product_benefits], style: row_styles
+    end
+
+     # merge category cells
+    category_start_row = 5
+    category_end_row = category_start_row + category_length - 1
+    category_cells = "A#{category_start_row}:A#{category_end_row}"
+    sheet.merge_cells(category_cells)
+
+    # columns widths
+    number_of_selected_products = @comparison_health_policies.length
+    product_column_widths = Array.new(number_of_selected_products) { 40 }
+    sheet.column_widths 25, 25, *product_column_widths
+
+    # apply styles
+    last_col = Axlsx.col_ref(sheet.cols.size - 1)
+    sheet.add_style "A1:#{last_col}#{category_end_row}", center_text
+    sheet.add_style "A#{category_start_row}:#{last_col}#{category_end_row}",
+                    center_text,
+                    border: { style: :thin, color: "000000" }
+    sheet.add_style "C1:#{last_col}4", border: { style: :thin, color: "000000", edges: %i[left right] }, b: true
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/models/health_insurance_policy_spec.rb
+++ b/spec/models/health_insurance_policy_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe HealthInsurancePolicy, type: :model do
                                                       medical_benefit: medical_benefit)
             end
             create(:product_module, :elective_product_module, id: 2, name: "Evacuation", 
-product: product) do |elective_product_module|
+                                                              product: product) do |elective_product_module|
               create(:linked_product_module, core_product_module: core_product_module,
                                              elective_product_module: elective_product_module)
             end
@@ -138,7 +138,7 @@ product: product) do |elective_product_module|
                                                       medical_benefit: medical_benefit)
             end
             create(:product_module, :elective_product_module, id: 2, name: "Evacuation", 
-product: product) do |elective_product_module|
+                                                              product: product) do |elective_product_module|
               create(:linked_product_module, core_product_module: core_product_module,
                                              elective_product_module: elective_product_module)
             end
@@ -149,6 +149,45 @@ product: product) do |elective_product_module|
 
     it "maps the product module names into an array" do
       expect(health_insurance_policy.product_module_names).to eq ["Gold", "Evacuation"]
+    end
+  end
+
+  describe "#overall_sum_assured" do
+    subject(:health_insurance_policy) { described_class.new(params) }
+
+    let(:params) do
+      {
+        "insurer_id" => 1,
+        "product_id" => 2,
+        "core_product_module_id" => 1,
+        "elective_product_module_ids" => [2],
+        "id" => "1234"
+      }
+    end
+    let(:product_module_medical_benefit) { ProductModuleMedicalBenefit.find(1) }
+
+    before do
+      create(:insurer, id: 1) do |insurer|
+        create(:product, id: 2, insurer: insurer) do |product|
+          create(:product_module, :core_product_module, id: 1, sum_assured: "100", 
+product: product) do |core_product_module|
+            create(:medical_benefit, id: 1) do |medical_benefit|
+              create(:product_module_medical_benefit, id: 1,
+                                                      product_module: core_product_module,
+                                                      medical_benefit: medical_benefit)
+            end
+            create(:product_module, :elective_product_module, id: 2, name: "Evacuation", 
+                                                              product: product) do |elective_product_module|
+              create(:linked_product_module, core_product_module: core_product_module,
+                                             elective_product_module: elective_product_module)
+            end
+          end
+        end
+      end
+    end
+
+    it "returns the sum assured of the core product module" do
+      expect(health_insurance_policy.overall_sum_assured).to eq "100"
     end
   end
 end


### PR DESCRIPTION
Because
The health insurance comparison show view only provides a very simple
view of the data, it doesn't give sufficient information about the
actual benefit coverage.

Allowing an excel export means the full benefit limit information can
be provided in a spreadsheet with navigation between the different
benefit categories handled by a spreadsheet tab for each category

Each benefit cell is colour-coded according to coverage. Green when the
benefit is paid in full. Orange when it is capped or red when it isn't
covered by that plan in the comparison.

This commit:

* Add caxslx, caxlsx_rails and axlsx_styler gems
* Add excel logo svg
* Add overall_sum_assured method to HealthInsurancePolicy model
* Add xlsx response format to health plan comparisons controller show method
* Add benefit_limit method to NullProductModuleMedicalBenefit model
* Add export link to health comparison show page
* Add xlsx health plan comparison show view page

closes #374 