### PR TITLE
Combined limits story

### DIFF
--- a/app/controllers/health_plan_comparisons_controller.rb
+++ b/app/controllers/health_plan_comparisons_controller.rb
@@ -1,5 +1,6 @@
 class HealthPlanComparisonsController < ApplicationController
   before_action :reset_comparison_health_policies_session, only: [:new]
+  before_action :set_combined_limits_boolean, only: [:show]
 
   def new
     @health_insurance_policy = create_health_insurance_policy
@@ -46,5 +47,9 @@ class HealthPlanComparisonsController < ApplicationController
 
   def comparison_health_policies
     session[:comparison_health_policies] ||= []
+  end
+
+  def set_combined_limits_boolean
+    @combined_limits = params[:combined_limits] == "1"
   end
 end

--- a/app/dashboards/product_module_medical_benefit_dashboard.rb
+++ b/app/dashboards/product_module_medical_benefit_dashboard.rb
@@ -15,6 +15,7 @@ class ProductModuleMedicalBenefitDashboard < Administrate::BaseDashboard
     benefit_limit_status: Field::Select.with_options(searchable: false, collection: ->(field) {
  field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     benefit_weighting: Field::Number,
+    combined_limits: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -40,6 +41,7 @@ class ProductModuleMedicalBenefitDashboard < Administrate::BaseDashboard
     benefit_limit
     benefit_limit_status
     benefit_weighting
+    combined_limits
     created_at
     updated_at
   ].freeze
@@ -53,6 +55,7 @@ class ProductModuleMedicalBenefitDashboard < Administrate::BaseDashboard
     benefit_limit
     benefit_limit_status
     benefit_weighting
+    combined_limits
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/nulls/null_product_module_medical_benefit.rb
+++ b/app/nulls/null_product_module_medical_benefit.rb
@@ -6,4 +6,8 @@ class NullProductModuleMedicalBenefit
   def benefit_limit
     "Not Covered"
   end
+
+  def combined_limits
+    ""
+  end
 end

--- a/app/views/health_plan_comparisons/show.html.erb
+++ b/app/views/health_plan_comparisons/show.html.erb
@@ -43,9 +43,16 @@
           <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
             <div class="flex flex-col gap-x-2 items-center">
               <h3>Export</h3>
-              <%= link_to health_plan_comparisons_path(format: :xlsx), target: '_blank' do %>
-                <%= inline_svg "icons/excel-logo.svg", class: "h-8 w-8" %>
-              <% end %>
+              <div class="mt-3">
+                <%= form_with url: health_plan_comparisons_path, method: :get, html: { class: 'space-y-6' }, builder: TailwindFormBuilder do |form| %>
+                  <div class="mt-3 flex space-x-2">
+                    <%= form.check_box :combined_limits %>
+                    <%= form.label :combined_limits %>
+                  </div>
+                  <div class="mt-3 flex justify-center">
+                    <%= image_submit_tag "icons/excel-logo.svg", class: 'h-8 w-8', formaction: health_plan_comparisons_path(format: :xlsx) %>
+                <% end %>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/health_plan_comparisons/show.xlsx.axlsx
+++ b/app/views/health_plan_comparisons/show.xlsx.axlsx
@@ -52,8 +52,12 @@ comparison_product_headers = {
         matched_benefit = policy.product_module_medical_benefit(benefit.id)
 
         row_styles << benefit_coverage_styles[matched_benefit.benefit_limit_status]
-
-        matched_benefit.benefit_limit
+        
+        if @combined_limits
+          "#{matched_benefit.benefit_limit}\n\n#{matched_benefit.combined_limits}"
+        else
+          matched_benefit.benefit_limit
+        end
       end
 
       sheet.add_row [category.titleize, benefit.name.titleize, *selected_product_benefits], style: row_styles

--- a/db/migrate/20220713133205_add_combined_limits_to_product_module_medical_benefits.rb
+++ b/db/migrate/20220713133205_add_combined_limits_to_product_module_medical_benefits.rb
@@ -1,0 +1,5 @@
+class AddCombinedLimitsToProductModuleMedicalBenefits < ActiveRecord::Migration[7.0]
+  def change
+    add_column :product_module_medical_benefits, :combined_limits, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_08_203616) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_13_133205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_08_203616) do
     t.integer "benefit_weighting", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "combined_limits"
     t.index ["medical_benefit_id"], name: "index_product_module_medical_benefits_on_medical_benefit_id"
     t.index ["product_module_id", "medical_benefit_id"], name: "index_product_module_benefits_on_product_module_and_benefit", unique: true
     t.index ["product_module_id"], name: "index_product_module_medical_benefits_on_product_module_id"
@@ -102,14 +103,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_08_203616) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.datetime "invitation_accepted_at", precision: nil
     t.integer "invitation_limit"
     t.string "invited_by_type"
     t.bigint "invited_by_id"

--- a/spec/factories/product_module_medical_benefits.rb
+++ b/spec/factories/product_module_medical_benefits.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     benefit_limit { "MyString" }
     benefit_limit_status { "paid_in_full" }
     benefit_weighting { 0 }
+    combined_limits { "USD 5,000 | GBP 3,000 | EUR 4,000" }
   end
 end


### PR DESCRIPTION
Because
The text around combined limits for each benefit can be quite long and
not always required to show on every comparison export

This commit:

* Add combined_limits column to ProductModuleMedicalBenefits table
* Update ProductModuleMedicalBenefit factory to add combined_limit
* Add combined_limits method to NullProductModuleMedicalBenefit
* Add combined_limits attribute to ProductModuleMedicalBenefit admin dashboard
* Set combined_limits variable in comparison controller show method
* Add form for setting the combined_limits checkbox before exporting to excel
* Add combined limits text to spreadsheet if combined_limits boolean is set

closes #394 