### PR TITLE
Add strip method to benefit output string in comparison excel show view

### DIFF
--- a/app/views/health_plan_comparisons/show.xlsx.axlsx
+++ b/app/views/health_plan_comparisons/show.xlsx.axlsx
@@ -54,7 +54,7 @@ comparison_product_headers = {
         row_styles << benefit_coverage_styles[matched_benefit.benefit_limit_status]
         
         if @combined_limits
-          "#{matched_benefit.benefit_limit}\n\n#{matched_benefit.combined_limits}"
+          "#{matched_benefit.benefit_limit}\n\n#{matched_benefit.combined_limits}".strip
         else
           matched_benefit.benefit_limit
         end


### PR DESCRIPTION
Because
When in the excel output file for a health comparison, and a product module medical benefit had a blank combined limits attribute, it still output the two line breaks that split the combined limit from the benefit limit. This made the row height too high for those benefits with no combined limits

This commit:
* Adds the split method to the string that outputs the combined limits if selected