### PR TITLE
Validate a Health Insurance Policy object

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -27,3 +27,10 @@
     @apply mt-0 mb-2 text-base font-medium leading-tight text-gray-600;
   }
 }
+
+.field_with_errors > label {
+  @apply block text-sm font-medium text-red-500;
+}
+.field_with_errors > select {
+  @apply appearance-none block w-full px-3 py-2 border border-red-500 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm;
+}

--- a/app/controllers/comparisons/health_insurance_policies_controller.rb
+++ b/app/controllers/comparisons/health_insurance_policies_controller.rb
@@ -1,9 +1,16 @@
 module Comparisons
   class HealthInsurancePoliciesController < ApplicationController
     def create
-      health_insurance_policy = HealthInsurancePolicy.from_elective_module_ids_hash(health_insurance_policy_params)
-      comparison_health_policies << health_insurance_policy.to_h
-      redirect_to new_health_plan_comparisons_path
+      @health_insurance_policy = HealthInsurancePolicy.from_elective_module_ids_hash(health_insurance_policy_params)
+
+      if @health_insurance_policy.valid?
+        comparison_health_policies << @health_insurance_policy.to_h
+        redirect_to new_health_plan_comparisons_path
+      else
+        flash.now['alert'] = @health_insurance_policy.errors.full_messages.join('</br>')
+        @comparison_health_policies = comparison_health_insurance_policies
+        render "health_plan_comparisons/new", status: :unprocessable_entity
+      end
     end
 
     def destroy
@@ -27,6 +34,12 @@ module Comparisons
 
     def comparison_health_policies
       session[:comparison_health_policies] ||= []
+    end
+
+    def comparison_health_insurance_policies
+      comparison_health_policies.map do |policy|
+        HealthInsurancePolicy.new(policy)
+      end
     end
   end
 end

--- a/app/models/health_insurance_policy.rb
+++ b/app/models/health_insurance_policy.rb
@@ -5,12 +5,16 @@ class HealthInsurancePolicy
 
   attr_accessor :insurer_id, :product_id, :core_product_module_id, :elective_product_module_ids, :id
 
+  validates :insurer_id, presence: true
+  validates :product_id, presence: true
+  validates :core_product_module_id, presence: true
+
   class << self
     def from_elective_module_ids_hash(params)
       new(
-        insurer_id: params["insurer_id"].to_i,
-        product_id: params["product_id"].to_i,
-        core_product_module_id: params["core_product_module_id"].to_i,
+        insurer_id: params["insurer_id"],
+        product_id: params["product_id"],
+        core_product_module_id: params["core_product_module_id"],
         elective_product_module_ids: elective_ids_from_hash(params["elective_product_module_ids"]),
         id: params["id"]
       )

--- a/spec/models/health_insurance_policy_spec.rb
+++ b/spec/models/health_insurance_policy_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe HealthInsurancePolicy, type: :model do
+  subject(:health_insurance_policy) { described_class.new(params) }
+
+  let(:params) do
+    {
+      "insurer_id" => 1,
+      "product_id" => 2,
+      "core_product_module_id" => 1,
+      "elective_product_module_ids" => [1, 2],
+      "id" => "123"
+    }
+  end
+
+  it { expect(health_insurance_policy).to validate_presence_of(:insurer_id) }
+  it { expect(health_insurance_policy).to validate_presence_of(:product_id) }
+  it { expect(health_insurance_policy).to validate_presence_of(:core_product_module_id) }
+  
   describe ".from_elective_module_ids_hash" do
     let(:params) do
       {


### PR DESCRIPTION
Because:
Health Insurance Policy selections were not being validated before
being added to the comparison list

This commit:

* Add health insurance policy validations for insurer_id, product_id and core_product_module_id
* remove conversion of params to integers in health insurance policy from_elective_module_ids_hash
* validate health insurance policy in controller
* Add tailwind class styles for field_with_errors class

closes #431 