### PR TITLE
Show product module limit story

### DIFF
--- a/app/controllers/health_plan_comparisons_controller.rb
+++ b/app/controllers/health_plan_comparisons_controller.rb
@@ -1,6 +1,6 @@
 class HealthPlanComparisonsController < ApplicationController
   before_action :reset_comparison_health_policies_session, only: [:new]
-  before_action :set_combined_limits_boolean, only: [:show]
+  before_action :set_benefit_view_options, only: [:show]
 
   def new
     @health_insurance_policy = create_health_insurance_policy
@@ -49,7 +49,8 @@ class HealthPlanComparisonsController < ApplicationController
     session[:comparison_health_policies] ||= []
   end
 
-  def set_combined_limits_boolean
-    @combined_limits = params[:combined_limits] == "1"
+  def set_benefit_view_options
+    @benefit_view_options = params['benefit_view_options']
+      .reject { |_, v| v == "0" }.keys if params['benefit_view_options']
   end
 end

--- a/app/decorators/product_module_medical_benefit_decorator.rb
+++ b/app/decorators/product_module_medical_benefit_decorator.rb
@@ -1,0 +1,28 @@
+class ProductModuleMedicalBenefitDecorator < SimpleDelegator
+  def benefit_limits(options)
+    selected_benefit_limits(options)
+     .join("\n\n")
+     .strip
+  end
+
+  private
+
+  def selected_benefit_limits(options)
+    arr = [benefit_limit]
+
+    options.each do |option|
+      next if option_mapper[option].blank?
+
+      arr.push(option_mapper[option])
+    end
+
+    arr
+  end
+
+  def option_mapper
+    {
+      "combined_limits" => combined_limits,
+      "module_limits" => product_module.sum_assured
+    }
+  end
+end

--- a/app/nulls/null_product_module.rb
+++ b/app/nulls/null_product_module.rb
@@ -1,0 +1,5 @@
+class NullProductModule
+  def sum_assured
+    ""
+  end
+end

--- a/app/nulls/null_product_module_medical_benefit.rb
+++ b/app/nulls/null_product_module_medical_benefit.rb
@@ -10,4 +10,8 @@ class NullProductModuleMedicalBenefit
   def combined_limits
     ""
   end
+
+  def product_module
+    NullProductModule.new
+  end
 end

--- a/app/views/health_plan_comparisons/show.html.erb
+++ b/app/views/health_plan_comparisons/show.html.erb
@@ -46,8 +46,12 @@
               <div class="mt-3">
                 <%= form_with url: health_plan_comparisons_path, method: :get, html: { class: 'space-y-6' }, builder: TailwindFormBuilder do |form| %>
                   <div class="mt-3 flex space-x-2">
-                    <%= form.check_box :combined_limits %>
-                    <%= form.label :combined_limits %>
+                    <%= form.check_box 'benefit_view_options[combined_limits]' %>
+                    <%= form.label 'benefit_view_options[combined_limits]', "Combined limits" %>
+                  </div>
+                  <div class="mt-3 flex space-x-2">
+                    <%= form.check_box 'benefit_view_options[module_limits]' %>
+                    <%= form.label 'benefit_view_options[module_limits]', "Module limits" %>
                   </div>
                   <div class="mt-3 flex justify-center">
                     <%= image_submit_tag "icons/excel-logo.svg", class: 'h-8 w-8', formaction: health_plan_comparisons_path(format: :xlsx) %>

--- a/app/views/health_plan_comparisons/show.xlsx.axlsx
+++ b/app/views/health_plan_comparisons/show.xlsx.axlsx
@@ -49,15 +49,13 @@ comparison_product_headers = {
       row_styles = [category_colour, category_colour]
 
       selected_product_benefits = @comparison_health_policies.map do |policy|
-        matched_benefit = policy.product_module_medical_benefit(benefit.id)
+        decorated_product_module_medical_benefit = ProductModuleMedicalBenefitDecorator.new(
+          policy.product_module_medical_benefit(benefit.id)
+        )
 
-        row_styles << benefit_coverage_styles[matched_benefit.benefit_limit_status]
+        row_styles << benefit_coverage_styles[decorated_product_module_medical_benefit.benefit_limit_status]
         
-        if @combined_limits
-          "#{matched_benefit.benefit_limit}\n\n#{matched_benefit.combined_limits}".strip
-        else
-          matched_benefit.benefit_limit
-        end
+        decorated_product_module_medical_benefit.benefit_limits(@benefit_view_options)
       end
 
       sheet.add_row [category.titleize, benefit.name.titleize, *selected_product_benefits], style: row_styles

--- a/spec/decorators/product_module_medical_benefit_decorator_spec.rb
+++ b/spec/decorators/product_module_medical_benefit_decorator_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe ProductModuleMedicalBenefitDecorator do
+  subject(:decorator) { described_class.new(product_module) }
+
+  let(:product_module) do
+    build(:product_module_medical_benefit, benefit_limit: benefit_limit, combined_limits: combined_limits)
+  end
+  let(:benefit_limit) { 'unlimited' }
+  let(:combined_limits) { 'all inclusive' }
+
+  describe '#benefit_limits' do
+    context 'when no options are passed' do
+      let(:options) { [] }
+
+      it 'returns the benefit limit' do
+        expect(decorator.benefit_limits(options)).to eq('unlimited')
+      end
+    end
+
+    context 'when combined_limits option is passed' do
+      let(:options) { ['combined_limits'] }
+
+      it 'returns the benefit limit and combined limits separated by two newlines' do
+        expect(decorator.benefit_limits(options)).to eq("unlimited\n\nall inclusive")
+      end
+    end
+
+    context 'when module_limits option is passed' do
+      let(:options) { ['module_limits'] }
+
+      it 'returns the benefit limit and module limits separated by two newlines' do
+        expect(decorator.benefit_limits(options)).to eq("unlimited\n\nUSD 1,000,000 | GBP 600,000 | EUR 750,000")
+      end
+    end
+
+    context 'when both options are passed' do
+      let(:options) { ['combined_limits','module_limits'] }
+
+      it 'returns the benefit limit, combined limits and module limits separated by two newlines' do
+        expect(decorator.benefit_limits(options)).to eq(
+          "unlimited\n\nall inclusive\n\nUSD 1,000,000 | GBP 600,000 | EUR 750,000"
+        )
+      end
+    end
+
+    context 'when an option is passed but the mapped value is blank' do
+      let(:options) { ['combined_limits'] }
+      let(:combined_limits) { ''}
+
+      it 'does not include the combined limit or newlines in the output' do
+        expect(decorator.benefit_limits(options)).to eq('unlimited')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because
Users should be able to tell the product module limit for a health
insurance policies medical product_module_medical_benefit_decorator_spec

This commit:

* Add null product module
* Update comparison controller to accept options param
* Create product module medical benefit decorator
* Add decorator to show view

closes #453 