### PR TITLE
Add Coverage Category Taggings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "redis", "~> 4.8"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 
+gem 'acts-as-taggable-on', '~> 9.0'
 gem "administrate", github: "n-studio/administrate", branch: "compile-assets"
 gem "administrate_exportable", "~> 0.6.1"
 gem "axlsx_styler", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     administrate_exportable (0.6.1)
@@ -353,6 +355,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 9.0)
   administrate!
   administrate_exportable (~> 0.6.1)
   axlsx_styler (~> 1.2)

--- a/app/dashboards/core_product_module_dashboard.rb
+++ b/app/dashboards/core_product_module_dashboard.rb
@@ -18,6 +18,7 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
     type: Field::String,
     category: Field::Select.with_options(searchable: false, collection: ->(field) {
       field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    coverage_category_list: Field::String,
     sum_assured: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -48,6 +49,7 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
     type
     sum_assured
     category
+    coverage_category_list
     created_at
     updated_at
   ].freeze
@@ -65,6 +67,7 @@ class CoreProductModuleDashboard < Administrate::BaseDashboard
     type
     sum_assured
     category
+    coverage_category_list
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/dashboards/elective_product_module_dashboard.rb
+++ b/app/dashboards/elective_product_module_dashboard.rb
@@ -18,6 +18,7 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
     type: Field::String,
     category: Field::Select.with_options(searchable: false, collection: ->(field) {
       field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    coverage_category_list: Field::String,
     sum_assured: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -48,6 +49,7 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
     type
     sum_assured
     category
+    coverage_category_list
     created_at
     updated_at
   ].freeze
@@ -65,6 +67,7 @@ class ElectiveProductModuleDashboard < Administrate::BaseDashboard
     type
     sum_assured
     category
+    coverage_category_list
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/dashboards/product_module_dashboard.rb
+++ b/app/dashboards/product_module_dashboard.rb
@@ -16,6 +16,7 @@ class ProductModuleDashboard < Administrate::BaseDashboard
     type: Field::String,
     category: Field::Select.with_options(searchable: false, collection: ->(field) {
       field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    coverage_category_list: Field::String,
     sum_assured: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -44,6 +45,7 @@ class ProductModuleDashboard < Administrate::BaseDashboard
     type
     category
     sum_assured
+    coverage_category_list
     created_at
     updated_at
   ].freeze
@@ -59,6 +61,7 @@ class ProductModuleDashboard < Administrate::BaseDashboard
     type
     sum_assured
     category
+    coverage_category_list
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -6,9 +6,40 @@ class ProductModule < ApplicationRecord
   has_many :product_module_medical_benefits, dependent: :destroy
   has_many :medical_benefits, through: :product_module_medical_benefits
 
+  acts_as_taggable_on :coverage_categories
+
   enum category: { core: 0, outpatient: 1, medicines_and_appliances: 2, wellness: 3,
     maternity: 4, dental_and_optical: 5, evacuation_and_repatriation: 6, travel: 7 }
 
   validates :name, presence: true, uniqueness: { scope: %i[product_id], case_sensitive: false }
   validates :type, presence: true
+  
+  validate :coverage_categories_are_valid
+
+  private
+
+  def coverage_categories_are_valid
+    coverage_category_list.each do |coverage_category|
+      unless valid_coverage_categories.include?(coverage_category)
+        errors.add(:coverage_categories, "#{coverage_category} is not a valid coverage category")
+      end
+    end
+  end
+
+  #rubocop:disable Metrics/MethodLength
+  def valid_coverage_categories
+    %w[
+      inpatient
+      outpatient
+      therapists
+      medicines_and_appliances
+      wellness
+      maternity
+      dental
+      optical
+      evacuation
+      repatriation
+    ]
+  end
+  #rubocop:enable Metrics/MethodLength
 end

--- a/db/migrate/20221023210659_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20221023210659_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20221023210660_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20221023210660_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20221023210661_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20221023210661_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20221023210662_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20221023210662_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20221023210663_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20221023210663_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+#rubocop:disable Style/GuardClause
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end
+#rubocop:enable Style/GuardClause

--- a/db/migrate/20221023210664_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20221023210664_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+#rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end
+#rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_13_133205) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_23_210664) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,35 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_13_133205) do
     t.index ["insurer_id"], name: "index_products_on_insurer_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", precision: nil
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -131,4 +160,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_13_133205) do
   add_foreign_key "product_module_medical_benefits", "product_modules"
   add_foreign_key "product_modules", "products"
   add_foreign_key "products", "insurers"
+  add_foreign_key "taggings", "tags"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,6 +109,8 @@ FactoryBot.create(:medical_benefit, name: "Out of Area Cover", category: "additi
 FactoryBot.create(:insurer, name: "BUPA Global", logo_name: "bupa_global_logo.png") do |insurer|
   FactoryBot.create(:product, name: "Lifeline", insurer: insurer) do |product|
     FactoryBot.create(:product_module, :core_product_module, product: product, name: "Gold", sum_assured: "Unlimited", category: :core) do |product_module|
+      product_module.coverage_category_list = "inpatient, outpatient, therapists, medicines_and_appliances, wellness, maternity"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Hospital Accomodation"),
                                               benefit_limit: "Paid in full",
                                               benefit_limit_status: "paid_in_full",
@@ -318,6 +320,8 @@ FactoryBot.create(:insurer, name: "BUPA Global", logo_name: "bupa_global_logo.pn
                                               product_module: product_module)
     end
     FactoryBot.create(:product_module, :elective_product_module, product: product, name: "Evacuation", sum_assured: "Within Overall Limit", category: :evacuation_and_repatriation) do |product_module|
+      product_module.coverage_category_list = "evacuation"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Evacuation Transport Costs to Nearest Country"),
                                               benefit_limit: "Paid in full",
                                               benefit_limit_status: "paid_in_full",
@@ -336,6 +340,8 @@ FactoryBot.create(:insurer, name: "BUPA Global", logo_name: "bupa_global_logo.pn
                                               product_module: product_module)
     end
     FactoryBot.create(:product_module, :elective_product_module, product: product, name: "Repatriation", sum_assured: "Within Overall Limit", category: :evacuation_and_repatriation) do |product_module|
+      product_module.coverage_category_list = "repatriation"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Evacuation Transport Costs to Nearest Country"),
                                               benefit_limit: "Paid in full",
                                               benefit_limit_status: "paid_in_full",
@@ -368,6 +374,8 @@ end
 FactoryBot.create(:insurer, name: "Cigna Global", logo_name: "cigna_worldwide_logo.png") do |insurer|
   FactoryBot.create(:product, name: "Health Options", insurer: insurer) do |product|
     FactoryBot.create(:product_module, :core_product_module, product: product, name: "Platinum Inpatient", sum_assured: "Unlimited", category: :core) do |product_module|
+      product_module.coverage_category_list = "inpatient, maternity"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Hospital Accomodation"),
                                               benefit_limit: "Paid in full",
                                               benefit_limit_status: "paid_in_full",
@@ -475,6 +483,8 @@ FactoryBot.create(:insurer, name: "Cigna Global", logo_name: "cigna_worldwide_lo
       
     end
     FactoryBot.create(:product_module, :elective_product_module, product: product, name: "Platinum Outpatient", sum_assured: "Within Overall Limit", category: :outpatient) do |product_module|
+      product_module.coverage_category_list = "outpatient, therapists, medicines_and_appliances"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Consultants Fees"),
                                               benefit_limit: "Paid in full",
                                               benefit_limit_status: "paid_in_full",
@@ -529,6 +539,8 @@ FactoryBot.create(:insurer, name: "Cigna Global", logo_name: "cigna_worldwide_lo
                                               product_module: product_module)
     end
     FactoryBot.create(:product_module, :elective_product_module, product: product, name: "Platinum International Evacuation and Crisis Assistance Plus", sum_assured: "Within Overall Limit", category: :evacuation_and_repatriation) do |product_module|
+      product_module.coverage_category_list = "evacuation, repatriation"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Evacuation Transport Costs to Nearest Country"),
                                               benefit_limit: "Paid in full",
                                               benefit_limit_status: "paid_in_full",
@@ -551,12 +563,15 @@ FactoryBot.create(:insurer, name: "Cigna Global", logo_name: "cigna_worldwide_lo
                                               product_module: product_module)
     end
     FactoryBot.create(:product_module, :elective_product_module, product: product, name: "Platinum International Health and Wellbeing", sum_assured: "Within Overall Limit", category: :wellness) do |product_module|
+      product_module.coverage_category_list = "wellness"
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Health Screening and Wellness Checks"),
                                               benefit_limit: "USD 600 | GBP 400 | EUR 440 each membership year",
                                               benefit_limit_status: "capped",
                                               product_module: product_module)
     end
     FactoryBot.create(:product_module, :elective_product_module, product: product, name: "Platinum International Vision and Dental", sum_assured: "Within Overall Limit", category: :dental_and_optical) do |product_module|
+      product_module.coverage_category_list = "optical, dental"
+      product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Preventative"),
                                               benefit_limit: "USD 5,500 | GBP 3,500 | EUR 4,300 each membership year",
                                               benefit_limit_status: "capped",

--- a/spec/support/shared_examples/product_module.rb
+++ b/spec/support/shared_examples/product_module.rb
@@ -24,4 +24,14 @@ shared_examples "A ProductModule class" do
   it "validates the presence of type" do
     expect(subject).to validate_presence_of(:type)
   end
+
+  it "doesn't allow invalid coverage categories" do
+    subject.coverage_category_list.add("invalid")
+    expect(subject).to be_invalid
+  end
+
+  it "allows valid coverage categories" do
+    subject.coverage_category_list.add("inpatient")
+    expect(subject).to be_valid
+  end
 end


### PR DESCRIPTION
Because:
We need a way to identify which broad coverage is provided by a product module

This commit:

- Add acts_as_taggable gem
- Add acts_as_taggable migrations
- Add validation for coverage categories to product module
- Add coverage category list to product module admin dashboards
- Make valid coverage categories its own array rather than take the keys from the MedicalBenefit categories
- Add therapists to valid coverage categories array
- Add coverage categories to product modules in seeds file
- Fix rubocop warnings