### PR TITLE
Active Benefit Story

### DIFF
--- a/app/views/health_plan_comparisons/show.html.erb
+++ b/app/views/health_plan_comparisons/show.html.erb
@@ -53,6 +53,10 @@
                     <%= form.check_box 'benefit_view_options[module_limits]' %>
                     <%= form.label 'benefit_view_options[module_limits]', "Module limits" %>
                   </div>
+                  <div class="mt-3 flex space-x-2">
+                    <%= form.check_box 'benefit_view_options[active_benefits]' %>
+                    <%= form.label 'benefit_view_options[active_benefits]', "Active Benefits" %>
+                  </div>
                   <div class="mt-3 flex justify-center">
                     <%= image_submit_tag "icons/excel-logo.svg", class: 'h-8 w-8', formaction: health_plan_comparisons_path(format: :xlsx) %>
                 <% end %>


### PR DESCRIPTION
Because:
Health Insurance comparisons require the ability to show only those benefits where at least one of the plans has the benefit active.

This commit:

- Add active benefit checkbox to comparison view
- Add method to locate active benefits

closes #665 