### PR TITLE
Update comparison health insurance policy destroy method

### DIFF
--- a/app/controllers/comparisons/individual_international_health_insurances_controller.rb
+++ b/app/controllers/comparisons/individual_international_health_insurances_controller.rb
@@ -36,7 +36,7 @@ module Comparisons
     end
 
     def destroy
-      comparison_health_policies.delete_if { _1["id"] == params[:id] }
+      comparison_health_policies.delete_if { _1[:id] == params[:id] }
   
       respond_to do |format|
         format.html { redirect_to new_health_plan_comparisons_path }


### PR DESCRIPTION
Because
The comparison health insurance destroy method found with health insurance policy to remove based on its ID. The id key in the hash stored in the session was stored as a symbol but it was searching based on it being a string. Subsequently nothing was matching and the health insurance policy wasn't actually removed. A screen refresh meant it reappeared as it was still in the comparison session

This commit
- Change the destroy method of the health insurance comparison to search based on an symbol rather than a string