### PR TITLE
Create matched categories object

### DIFF
--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -1,19 +1,45 @@
 class RecommendationsController < ApplicationController
+  before_action :reset_recommendation_health_policies_session, only: [:new]
+
+  def show
+    @recommendation_health_policies = recommendation_health_insurance_policies
+  end
+
   def new
   end
 
   def create
-    @recommendation = format_coverage_requirements(recommendation_params)
+    @matched_products = HealthInsurancePolicies::MatchedCategories.match(
+      format_coverage_requirements(recommendation_params[:coverage_requirements])
+    )
+    @matched_products.each do |product|
+      recommendation_health_policies << product.to_h
+    end
+
+    redirect_to recommendations_path
   end
 
   private
+
+  def reset_recommendation_health_policies_session
+    session[:recommendation_health_policies] = nil
+  end
 
   def recommendation_params
     params.require(:recommendation).permit(coverage_requirements: {})
   end
 
   def format_coverage_requirements(params)
-    params[:coverage_requirements] = params[:coverage_requirements].reject { |_, v| v == "0" }.keys
-    params
+    params.reject { |_, v| v == "0" }.keys
+  end
+
+  def recommendation_health_policies
+    session[:recommendation_health_policies] ||= []
+  end
+
+  def recommendation_health_insurance_policies
+    recommendation_health_policies.map do |policy|
+      HealthInsurancePolicy.new(policy)
+    end
   end
 end

--- a/app/models/health_insurance_policy.rb
+++ b/app/models/health_insurance_policy.rb
@@ -92,9 +92,26 @@ class HealthInsurancePolicy
     core_product_module.sum_assured
   end
 
+  def valid_coverage_categories?(required_categories)
+    required_coverage_categories?(required_categories) && necessary_coverage_only?(required_categories)
+  end
+
   private
 
   def matching_benefits(benefit_id)
     product_module_medical_benefits.select { |medical_benefit| medical_benefit.medical_benefit.id == benefit_id }
+  end
+
+  def required_coverage_categories?(required_categories)
+    (required_categories - coverage_categories).empty?
+  end
+
+  def necessary_coverage_only?(required_categories)
+    (coverage_categories.exclude?("outpatient") && required_categories.exclude?("outpatient")) ||
+    (coverage_categories.include?("outpatient") && required_categories.include?("outpatient"))
+  end
+
+  def coverage_categories
+    product_modules.flat_map(&:coverage_category_list).uniq
   end
 end

--- a/app/services/health_insurance_policies/matched_categories.rb
+++ b/app/services/health_insurance_policies/matched_categories.rb
@@ -1,0 +1,54 @@
+module HealthInsurancePolicies
+  class MatchedCategories
+    attr_reader :categories, :policies
+
+    def self.match(categories)
+      new(categories).match
+    end
+
+    def initialize(categories)
+      @categories = categories
+      @policies = []
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def match
+      Insurer.find_each do |insurer|
+        insurer.products.each do |product|
+          product.core_product_modules.each do |core_product_module|
+            all_variations(
+              core_product_module,
+              grouped_modules(tagged_elective_product_modules(core_product_module))
+            ).each do |variation|
+              policy = HealthInsurancePolicy.new(
+                insurer_id: insurer.id,
+                product_id: product.id,
+                core_product_module_id: variation[0].id,
+                elective_product_module_ids: variation[1..].map(&:id)
+              )
+              policies.push(policy) if policy.valid_coverage_categories?(categories)
+            end
+          end
+        end
+      end
+      policies
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    private
+
+    def tagged_elective_product_modules(core_product_module)
+      core_product_module.elective_product_modules.tagged_with(categories, any: true)
+    end
+
+    def all_variations(core_product_module, grouped_elective_product_modules)
+      all_variations = [core_product_module].product(*grouped_elective_product_modules.values)
+      all_variations.prepend([core_product_module]) unless all_variations.any? { _1.size == 1 }
+      all_variations
+    end
+
+    def grouped_modules(product_modules)
+      product_modules.group_by(&:category)
+    end
+  end
+end

--- a/app/views/recommendations/show.html.erb
+++ b/app/views/recommendations/show.html.erb
@@ -1,0 +1,7 @@
+<%= render(DashboardMenuComponent.new) do %>
+  <div class="bg-white shadow overflow-hidden sm:rounded-md">
+    <ul role="list" class="divide-y divide-gray-200">
+      <%= render(HealthPolicyComparisonSelectionListComponent.with_collection(@recommendation_health_policies)) %>
+    </ul>
+  </div>
+<% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -340,7 +340,7 @@ FactoryBot.create(:insurer, name: "BUPA Global", logo_name: "bupa_global_logo.pn
                                               product_module:)
     end
     FactoryBot.create(:product_module, :elective_product_module, product:, name: "Repatriation", sum_assured: "Within Overall Limit", category: :evacuation_and_repatriation) do |product_module|
-      product_module.coverage_category_list = "repatriation"
+      product_module.coverage_category_list = "evacuation, repatriation"
       product_module.save
       FactoryBot.create(:product_module_medical_benefit, medical_benefit: MedicalBenefit.find_by(name: "Evacuation Transport Costs to Nearest Country"),
                                               benefit_limit: "Paid in full",

--- a/spec/factories/product_modules.rb
+++ b/spec/factories/product_modules.rb
@@ -14,6 +14,16 @@ FactoryBot.define do
       type { "ElectiveProductModule" }
     end
 
+    trait :with_coverage_categories do
+      transient do
+        coverage_categories { nil }
+      end
+
+      after(:create) do |product_module, evaluator| 
+        product_module.update(coverage_category_list: evaluator.coverage_categories)
+      end
+    end
+    
     initialize_with { type.present? ? type.constantize.new : ProductModule.new }
   end
 end

--- a/spec/services/health_insurance_policies/matched_categories_spec.rb
+++ b/spec/services/health_insurance_policies/matched_categories_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe HealthInsurancePolicies::MatchedCategories do
+  before do
+    create(:insurer, id: 1) do |insurer|
+      create(:product, id: 2, insurer:) do |product|
+        create(:product_module, :core_product_module, :with_coverage_categories, id: 1, name: "Essential",
+                 product:, coverage_categories: ["inpatient", "evacuation"]) do |core_product_module|
+          create(:product_module, :elective_product_module, :with_coverage_categories, id: 2, name: "Evacuation", 
+                   product:, coverage_categories: ["evacuation"]) do |elective_product_module|
+            create(:linked_product_module, core_product_module:, elective_product_module:)
+          end
+        end
+      end
+    end
+
+    create(:insurer, id: 10) do |insurer|
+      create(:product, id: 20, insurer:) do |product|
+        create(:product_module, :core_product_module, :with_coverage_categories, id: 10, name: "Classic",
+                 product:, coverage_categories: ["inpatient", "outpatient"]) do |core_product_module|
+          create(:product_module, :elective_product_module, :with_coverage_categories, id: 20, name: "Evacuation", 
+                   product:, coverage_categories: ["evacuation"]) do |elective_product_module|
+            create(:linked_product_module, core_product_module:, elective_product_module:)
+          end
+        end
+      end
+    end
+  end
+
+  describe '.match' do
+    context 'when only inpatient coverage is required' do
+      let(:categories) { ['inpatient'] }
+
+      it 'returns health insurance policies that cover inpatient' do
+        expect(described_class.match(categories)).to include(
+          an_object_having_attributes(insurer_id: 1, core_product_module_id: 1)
+        )
+      end
+
+      it 'does not return a health insurance policy with outpatient coverage' do
+        expect(described_class.match(categories)).not_to include(
+          an_object_having_attributes(insurer_id: 10)
+        )
+      end
+    end
+
+    context 'when outpatient coverage is required' do
+      let(:categories) { ['inpatient', 'outpatient'] }
+
+      it 'returns health insurance policies that cover outpatient' do
+        expect(described_class.match(categories)).to include(
+          an_object_having_attributes(insurer_id: 10)
+        )
+      end
+
+      it 'does not return a health insurance policy with no outpatient coverage' do
+        expect(described_class.match(categories)).not_to include(
+          an_object_having_attributes(insurer_id: 1)
+        )
+      end
+    end
+
+    context 'when an elective module does not contain a required coverage category' do
+      let(:categories) { ['inpatient'] }
+
+      it 'does not include the elective module' do
+        expect(described_class.match(categories)).not_to include(
+          an_object_having_attributes(elective_product_module_ids: [2])
+        )
+      end
+    end
+
+    context 'when both a core module and an elective module both contain a required coverage category' do
+      let(:categories) { ['inpatient', 'evacuation'] }
+
+      it 'includes a health insurance policy with only the core module covered' do
+        expect(described_class.match(categories)).to include(
+          an_object_having_attributes(core_product_module_id: 1, elective_product_module_ids: [])
+        )
+      end
+
+      it 'includes a health insurance policy with both the core module and elective module covered' do
+        expect(described_class.match(categories)).to include(
+          an_object_having_attributes(core_product_module_id: 1, elective_product_module_ids: [2])
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because
When the recommendation form is submitted the user needs to see the matched policies for the categories they have selected.

This commit

- Create matched categories object
- Add matched categories tests
- Add valid coverage categories method to health insurance policy model
- Update seeds file to add evacuation category
- Add with coverage categories trait to product modules factory
- Create recommendations controller
- Create recommendations show view